### PR TITLE
Stability and Info Labels

### DIFF
--- a/lib/api/api.dart
+++ b/lib/api/api.dart
@@ -81,6 +81,11 @@ class API {
   /// Returns `true` if it is a success or `false` if it failed.
   /// The found [Device] devices are saved in [Server.devices].
   Future<List<Device>?> getDevices(Server server) async {
+    if (!server.online) {
+      debugPrint('Can not get devices of an offline server: $server');
+      return [];
+    }
+
     try {
       assert(server.serverUUID != null && server.cookie != null);
       final response = await get(
@@ -133,6 +138,11 @@ class API {
     Server server, {
     int limit = 50,
   }) async {
+    if (!server.online) {
+      debugPrint('Can not get events of an offline server: $server');
+      return [];
+    }
+
     try {
       assert(server.serverUUID != null && server.cookie != null);
       final response = await get(

--- a/lib/api/api.dart
+++ b/lib/api/api.dart
@@ -152,6 +152,10 @@ class API {
           'Cookie': server.cookie!,
         },
       );
+
+      debugPrint('Getting events for server ${server.name}');
+      debugPrint(response.body);
+
       final parser = Xml2Json()..parse(response.body);
       return (await compute(jsonDecode, parser.toGData()))['feed']['entry']
           .map((e) {

--- a/lib/api/api.dart
+++ b/lib/api/api.dart
@@ -39,30 +39,26 @@ class API {
     try {
       final uri = Uri.https(
         '${server.ip}:${server.port}',
-        '/ajax/login.php',
+        '/ajax/loginapp.php',
         {
           'login': server.login,
           'password': server.password,
-          'from_client': true.toString(),
+          'from_client': 'true',
         },
       );
-      // final request = MultipartRequest('POST', uri)
-      //   // ..fields.addAll({
-      //   //   'login': server.login,
-      //   //   'password': server.password,
-      //   //   'from_client': true.toString(),
-      //   // })
-      //   ..headers.addAll({
-      //     'Content-Type': 'application/x-www-form-urlencoded',
-      //   });
-      // final response = await request.send();
-      // final body = await response.stream.bytesToString();
-      final response = await post(uri, headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      });
-      final body = response.body;
-      debugPrint(body.toString());
-      debugPrint(response.headers.toString());
+      final request = MultipartRequest('POST', uri)
+        ..fields.addAll({
+          'login': server.login,
+          'password': server.password,
+          'from_client': true.toString(),
+        })
+        ..headers.addAll({
+          'Content-Type': 'application/x-www-form-urlencoded',
+        });
+      final response = await request.send();
+      final body = await response.stream.bytesToString();
+      // debugPrint(body.toString());
+      // debugPrint(response.headers.toString());
 
       if (response.statusCode == 200) {
         final json = await compute(jsonDecode, body);

--- a/lib/api/api.dart
+++ b/lib/api/api.dart
@@ -35,16 +35,32 @@ class API {
   /// returned object will have [Server.serverUUID] & [Server.cookie]
   /// present in it otherwise `null`.
   Future<Server> checkServerCredentials(Server server) async {
+    debugPrint('Checking server credentials for server ${server.id}');
     try {
-      final uri =
-          Uri.https('${server.ip}:${server.port}', '/ajax/loginapp.php');
-      final request = MultipartRequest('POST', uri)
-        ..fields.addAll({
+      final uri = Uri.https(
+        '${server.ip}:${server.port}',
+        '/ajax/login.php',
+        {
           'login': server.login,
           'password': server.password,
-        });
-      final response = await request.send();
-      final body = await response.stream.bytesToString();
+          'from_client': true.toString(),
+        },
+      );
+      // final request = MultipartRequest('POST', uri)
+      //   // ..fields.addAll({
+      //   //   'login': server.login,
+      //   //   'password': server.password,
+      //   //   'from_client': true.toString(),
+      //   // })
+      //   ..headers.addAll({
+      //     'Content-Type': 'application/x-www-form-urlencoded',
+      //   });
+      // final response = await request.send();
+      // final body = await response.stream.bytesToString();
+      final response = await post(uri, headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      });
+      final body = response.body;
       debugPrint(body.toString());
       debugPrint(response.headers.toString());
 
@@ -53,12 +69,14 @@ class API {
         return server.copyWith(
           serverUUID: json['server_uuid'],
           cookie: response.headers['set-cookie'],
+          online: true,
         );
       }
     } catch (exception, stacktrace) {
       debugPrint('Failed to checkServerCredentials on server $server');
       debugPrint(exception.toString());
       debugPrint(stacktrace.toString());
+      server.online = false;
     }
     return server;
   }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -39,6 +39,7 @@
       "serverName": {}
     }
   },
+  "noServersAvailable": "No servers available",
   "error": "Error",
   "ok": "OK",
   "removeCamera": "Remove Camera",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -181,6 +181,15 @@ class UnityApp extends StatelessWidget {
         ChangeNotifierProvider<DownloadsManager>.value(
           value: DownloadsManager.instance,
         ),
+        ChangeNotifierProvider<MobileViewProvider>.value(
+          value: MobileViewProvider.instance,
+        ),
+        ChangeNotifierProvider<ServersProvider>.value(
+          value: ServersProvider.instance,
+        ),
+        ChangeNotifierProvider<EventsProvider>.value(
+          value: EventsProvider.instance,
+        ),
       ],
       child: Consumer<SettingsProvider>(
         builder: (context, settings, _) => MaterialApp(
@@ -199,7 +208,7 @@ class UnityApp extends StatelessWidget {
           darkTheme: createTheme(themeMode: ThemeMode.dark),
           initialRoute: '/',
           routes: {
-            '/': (context) => const MyHomePage(),
+            '/': (context) => const Home(),
           },
           onGenerateRoute: (settings) {
             if (settings.name == '/events') {
@@ -245,33 +254,6 @@ class UnityApp extends StatelessWidget {
           },
         ),
       ),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({Key? key}) : super(key: key);
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  @override
-  Widget build(BuildContext context) {
-    return MultiProvider(
-      providers: [
-        ChangeNotifierProvider<MobileViewProvider>.value(
-          value: MobileViewProvider.instance,
-        ),
-        ChangeNotifierProvider<ServersProvider>.value(
-          value: ServersProvider.instance,
-        ),
-        ChangeNotifierProvider<EventsProvider>.value(
-          value: EventsProvider.instance,
-        ),
-      ],
-      builder: (context, child) => const Home(),
     );
   }
 }

--- a/lib/models/event.dart
+++ b/lib/models/event.dart
@@ -73,7 +73,7 @@ class Event {
   Duration get duration {
     // return mediaDuration ?? updated.difference(published);
     // TODO(bdlukaa): for some reason, the diff is off by a few seconds. use this to counterpart the issue
-    final dur = updated.difference(published) - const Duration(seconds: 5);
+    final dur = updated.difference(published) - const Duration(seconds: 3);
     if (dur < Duration.zero) return updated.difference(published);
     return dur;
   }

--- a/lib/models/server.dart
+++ b/lib/models/server.dart
@@ -35,6 +35,8 @@ class Server {
   final String? serverUUID;
   final String? cookie;
 
+  bool online = true;
+
   Server(
     this.name,
     this.ip,
@@ -47,7 +49,12 @@ class Server {
     this.cookie,
     this.savePassword = false,
     this.connectAutomaticallyAtStartup = true,
+    this.online = true,
   });
+
+  String get id {
+    return '$name;$ip;$port';
+  }
 
   @override
   String toString() =>
@@ -81,6 +88,7 @@ class Server {
     List<Device>? devices,
     String? serverUUID,
     String? cookie,
+    bool? online,
   }) {
     return Server(
       name ?? this.name,

--- a/lib/providers/desktop_view_provider.dart
+++ b/lib/providers/desktop_view_provider.dart
@@ -158,9 +158,30 @@ class DesktopViewProvider extends ChangeNotifier {
     return _save(notifyListeners: false);
   }
 
+  /// Removes all the [devices] provided
+  ///
+  /// This is usually used when a server is deleted
+  Future<void> removeDevices(List<Device> devices) {
+    for (final layout in layouts) {
+      layout.devices.removeWhere(
+        (d1) => devices.any((d2) => d1.uri == d2.uri),
+      );
+    }
+
+    for (final device in devices) {
+      if (!players.containsKey(device)) continue;
+      players[device]?.release();
+      players[device]?.dispose();
+    }
+
+    return _save();
+  }
+
   /// Moves a device tile from [initial] position to [end] position inside a [tab].
   /// Used for re-ordering camera [DeviceTile]s when dragging.
   Future<void> reorder(int initial, int end) {
+    if (initial == end) return Future.value();
+
     currentLayout.devices.insert(end, currentLayout.devices.removeAt(initial));
     // Prevent redundant latency.
     notifyListeners();

--- a/lib/widgets/device_grid/desktop_sidebar.dart
+++ b/lib/widgets/device_grid/desktop_sidebar.dart
@@ -39,6 +39,7 @@ class _DesktopSidebarState extends State<DesktopSidebar> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
+    final servers = context.watch<ServersProvider>();
     final view = context.watch<DesktopViewProvider>();
 
     return Material(
@@ -56,17 +57,35 @@ class _DesktopSidebarState extends State<DesktopSidebar> {
               itemBuilder: (context, i) {
                 final server = ServersProvider.instance.servers[i];
                 final devices = server.devices.sorted();
+                final isLoading = servers.isServerLoading(server);
+
                 return ListView.builder(
                   shrinkWrap: true,
                   physics: const NeverScrollableScrollPhysics(),
-                  itemCount: devices.length + 1,
+                  itemCount:
+                      !server.online || isLoading ? 1 : devices.length + 1,
                   itemBuilder: (context, index) {
                     if (index == 0) {
                       return SubHeader(
                         server.name,
-                        subtext: AppLocalizations.of(context).nDevices(
-                          devices.length,
+                        subtext: server.online
+                            ? AppLocalizations.of(context).nDevices(
+                                devices.length,
+                              )
+                            : AppLocalizations.of(context).offline,
+                        subtextStyle: TextStyle(
+                          color:
+                              !server.online ? theme.colorScheme.error : null,
                         ),
+                        trailing: isLoading
+                            ? const SizedBox(
+                                height: 16.0,
+                                width: 16.0,
+                                child: CircularProgressIndicator.adaptive(
+                                  strokeWidth: 1.5,
+                                ),
+                              )
+                            : null,
                       );
                     }
 

--- a/lib/widgets/device_selector_screen.dart
+++ b/lib/widgets/device_selector_screen.dart
@@ -34,72 +34,93 @@ class DeviceSelectorScreen extends StatefulWidget {
 class _DeviceSelectorScreenState extends State<DeviceSelectorScreen> {
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     final servers = context.watch<ServersProvider>();
+    final loc = AppLocalizations.of(context);
+    final viewPadding = MediaQuery.viewPaddingOf(context);
 
     return Scaffold(
-      appBar: AppBar(
-        title: Text(AppLocalizations.of(context).selectACamera),
-      ),
-      body: SafeArea(
-        bottom: false,
-        child: () {
-          if (servers.servers.isEmpty) {
-            return const NoServerWarning();
-          }
+      appBar: AppBar(title: Text(loc.selectACamera)),
+      body: () {
+        if (servers.servers.isEmpty) {
+          return const NoServerWarning();
+        }
 
-          return ListView.builder(
-            itemCount: servers.servers.length,
-            itemBuilder: (context, index) {
-              final server = servers.servers[index];
-              final isLoading = servers.isServerLoading(server);
+        return ListView.builder(
+          itemCount: servers.servers.length,
+          itemBuilder: (context, index) {
+            final server = servers.servers[index];
+            final isLoading = servers.isServerLoading(server);
 
-              if (isLoading) {
-                return Center(
-                  child: Container(
-                    alignment: AlignmentDirectional.center,
-                    height: 156.0,
-                    child: const CircularProgressIndicator(),
-                  ),
-                );
-              }
-
-              return ListView.builder(
-                shrinkWrap: true,
-                physics: const NeverScrollableScrollPhysics(),
-                itemCount: server.devices.length + 1,
-                itemBuilder: (context, index) {
-                  if (index == 0) return SubHeader(server.name);
-                  index--;
-                  return ListTile(
-                    enabled: server.devices[index].status,
-                    leading: CircleAvatar(
-                      backgroundColor: Colors.transparent,
-                      foregroundColor: Theme.of(context).iconTheme.color,
-                      child: const Icon(Icons.camera_alt),
-                    ),
-                    title: Text(
-                      server.devices[index].name
-                          .split(' ')
-                          .map((e) => e[0].toUpperCase() + e.substring(1))
-                          .join(' '),
-                    ),
-                    subtitle: Text([
-                      server.devices[index].status
-                          ? AppLocalizations.of(context).online
-                          : AppLocalizations.of(context).offline,
-                      server.devices[index].uri,
-                      '${server.devices[index].resolutionX}x${server.devices[index].resolutionY}',
-                    ].join(' • ')),
-                    onTap: () {
-                      Navigator.of(context).pop(server.devices[index]);
-                    },
-                  );
-                },
+            if (isLoading) {
+              return Center(
+                child: Container(
+                  alignment: AlignmentDirectional.center,
+                  height: 156.0,
+                  child: const CircularProgressIndicator(),
+                ),
               );
-            },
-          );
-        }(),
-      ),
+            }
+
+            return ListView.builder(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              itemCount: server.devices.length + 1,
+              padding: EdgeInsets.only(
+                left: viewPadding.left,
+                right: viewPadding.right,
+                bottom: viewPadding.bottom,
+              ),
+              itemBuilder: (context, index) {
+                if (index == 0) {
+                  return SubHeader(
+                    server.name,
+                    subtext: server.online
+                        ? loc.nDevices(server.devices.length)
+                        : loc.offline,
+                    subtextStyle: TextStyle(
+                      color: !server.online ? theme.colorScheme.error : null,
+                    ),
+                    trailing: isLoading
+                        ? const SizedBox(
+                            height: 16.0,
+                            width: 16.0,
+                            child: CircularProgressIndicator.adaptive(
+                              strokeWidth: 1.5,
+                            ),
+                          )
+                        : null,
+                  );
+                }
+
+                index--;
+                return ListTile(
+                  enabled: server.devices[index].status,
+                  leading: CircleAvatar(
+                    backgroundColor: Colors.transparent,
+                    foregroundColor: Theme.of(context).iconTheme.color,
+                    child: const Icon(Icons.camera_alt),
+                  ),
+                  title: Text(
+                    server.devices[index].name
+                        .split(' ')
+                        .map((e) => e[0].toUpperCase() + e.substring(1))
+                        .join(' '),
+                  ),
+                  subtitle: Text([
+                    server.devices[index].status ? loc.online : loc.offline,
+                    server.devices[index].uri,
+                    '${server.devices[index].resolutionX}x${server.devices[index].resolutionY}',
+                  ].join(' • ')),
+                  onTap: () {
+                    Navigator.of(context).pop(server.devices[index]);
+                  },
+                );
+              },
+            );
+          },
+        );
+      }(),
     );
   }
 }

--- a/lib/widgets/direct_camera.dart
+++ b/lib/widgets/direct_camera.dart
@@ -83,26 +83,55 @@ class _DevicesForServer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final servers = context.watch<ServersProvider>();
+
+    final isLoading = servers.isServerLoading(server);
+
+    final serverIndicator = SubHeader(
+      server.name,
+      subtext: server.online
+          ? AppLocalizations.of(context).nDevices(
+              server.devices.length,
+            )
+          : AppLocalizations.of(context).offline,
+      subtextStyle: TextStyle(
+        color: !server.online ? theme.colorScheme.error : null,
+      ),
+      trailing: isLoading
+          ? const SizedBox(
+              height: 16.0,
+              width: 16.0,
+              child: CircularProgressIndicator.adaptive(strokeWidth: 1.5),
+            )
+          : null,
+    );
+
+    if (isLoading || !server.online) return serverIndicator;
+
     if (server.devices.isEmpty) {
-      return SizedBox(
-        height: 72.0,
-        child: Center(
-          child: Text(
-            AppLocalizations.of(context).noDevices,
-            style: Theme.of(context)
-                .textTheme
-                .headlineSmall
-                ?.copyWith(fontSize: 16.0),
+      return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+        serverIndicator,
+        SizedBox(
+          height: 72.0,
+          child: Center(
+            child: Text(
+              AppLocalizations.of(context).noDevices,
+              style: Theme.of(context)
+                  .textTheme
+                  .headlineSmall
+                  ?.copyWith(fontSize: 16.0),
+            ),
           ),
         ),
-      );
+      ]);
     }
 
     final devices = server.devices.sorted();
     return LayoutBuilder(builder: (context, consts) {
       if (consts.maxWidth >= 800) {
         return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-          SubHeader(server.name),
+          serverIndicator,
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 10.0),
             child: Wrap(
@@ -155,6 +184,7 @@ class _DevicesForServer extends StatelessWidget {
           ),
         ]);
       }
+
       return Column(children: [
         SubHeader(server.name),
         ...devices.map((device) {

--- a/lib/widgets/events/events_screen.dart
+++ b/lib/widgets/events/events_screen.dart
@@ -77,7 +77,8 @@ class _EventsScreenState extends State<EventsScreen> {
     final home = context.read<HomeProvider>()
       ..loading(UnityLoadingReason.fetchingEventsHistory);
     try {
-      for (final server in ServersProvider.instance.servers) {
+      // Load the events at the same time
+      await Future.wait(ServersProvider.instance.servers.map((server) async {
         try {
           final iterable = await API.instance.getEvents(
             await API.instance.checkServerCredentials(server),
@@ -89,7 +90,7 @@ class _EventsScreenState extends State<EventsScreen> {
           debugPrint(stacktrace.toString());
           invalid[server] = true;
         }
-      }
+      }));
     } catch (exception, stacktrace) {
       debugPrint(exception.toString());
       debugPrint(stacktrace.toString());

--- a/lib/widgets/events_playback/events_playback_desktop.dart
+++ b/lib/widgets/events_playback/events_playback_desktop.dart
@@ -373,15 +373,7 @@ class Sidebar extends StatelessWidget {
                   itemBuilder: (context, index) {
                     final server = servers.elementAt(index);
 
-                    if (!serversProvider.isServerLoading(server)) {
-                      return Center(
-                        child: Container(
-                          alignment: AlignmentDirectional.center,
-                          height: 156.0,
-                          child: const LinearProgressIndicator(),
-                        ),
-                      );
-                    }
+                    final isLoading = serversProvider.isServerLoading(server);
 
                     final devices = server.devices.sorted();
 
@@ -393,14 +385,29 @@ class Sidebar extends StatelessWidget {
                         if (index == 0) {
                           return SubHeader(
                             server.name,
-                            subtext: AppLocalizations.of(context).nDevices(
-                              devices.length,
+                            subtext: server.online
+                                ? AppLocalizations.of(context).nDevices(
+                                    devices.length,
+                                  )
+                                : AppLocalizations.of(context).offline,
+                            subtextStyle: TextStyle(
+                              color: !server.online
+                                  ? Theme.of(context).colorScheme.error
+                                  : null,
                             ),
                             padding: const EdgeInsetsDirectional.only(
                               start: 16.0,
                               end: 6.0,
                             ),
-                            trailing: collapseButton,
+                            trailing: isLoading
+                                ? const SizedBox(
+                                    height: 16.0,
+                                    width: 16.0,
+                                    child: CircularProgressIndicator.adaptive(
+                                      strokeWidth: 1.5,
+                                    ),
+                                  )
+                                : collapseButton,
                           );
                         }
 

--- a/lib/widgets/events_playback/events_playback_desktop.dart
+++ b/lib/widgets/events_playback/events_playback_desktop.dart
@@ -359,68 +359,74 @@ class Sidebar extends StatelessWidget {
     return Material(
       child: Column(children: [
         Expanded(
-          child: ListView.builder(
-            padding: EdgeInsets.only(
-              bottom: MediaQuery.viewPaddingOf(context).bottom,
-            ),
-            itemCount: servers.length,
-            itemBuilder: (context, index) {
-              final server = servers.elementAt(index);
-
-              if (!serversProvider.isServerLoading(server)) {
-                return Center(
-                  child: Container(
-                    alignment: AlignmentDirectional.center,
-                    height: 156.0,
-                    child: const LinearProgressIndicator(),
+          child: servers.isEmpty
+              ? Center(
+                  child: Text(
+                    AppLocalizations.of(context).noServersAvailable,
                   ),
-                );
-              }
+                )
+              : ListView.builder(
+                  padding: EdgeInsets.only(
+                    bottom: MediaQuery.viewPaddingOf(context).bottom,
+                  ),
+                  itemCount: servers.length,
+                  itemBuilder: (context, index) {
+                    final server = servers.elementAt(index);
 
-              final devices = server.devices.sorted();
+                    if (!serversProvider.isServerLoading(server)) {
+                      return Center(
+                        child: Container(
+                          alignment: AlignmentDirectional.center,
+                          height: 156.0,
+                          child: const LinearProgressIndicator(),
+                        ),
+                      );
+                    }
 
-              return ListView.builder(
-                shrinkWrap: true,
-                physics: const NeverScrollableScrollPhysics(),
-                itemCount: devices.length + 1,
-                itemBuilder: (context, index) {
-                  if (index == 0) {
-                    return SubHeader(
-                      server.name,
-                      subtext: AppLocalizations.of(context).nDevices(
-                        devices.length,
-                      ),
-                      padding: const EdgeInsetsDirectional.only(
-                        start: 16.0,
-                        end: 6.0,
-                      ),
-                      trailing: collapseButton,
+                    final devices = server.devices.sorted();
+
+                    return ListView.builder(
+                      shrinkWrap: true,
+                      physics: const NeverScrollableScrollPhysics(),
+                      itemCount: devices.length + 1,
+                      itemBuilder: (context, index) {
+                        if (index == 0) {
+                          return SubHeader(
+                            server.name,
+                            subtext: AppLocalizations.of(context).nDevices(
+                              devices.length,
+                            ),
+                            padding: const EdgeInsetsDirectional.only(
+                              start: 16.0,
+                              end: 6.0,
+                            ),
+                            trailing: collapseButton,
+                          );
+                        }
+
+                        index--;
+                        final device = devices[index];
+                        if (!this
+                            .events
+                            .keys
+                            .contains(EventsProvider.idForDevice(device))) {
+                          return const SizedBox.shrink();
+                        }
+
+                        final selected = events.selectedIds
+                            .contains(EventsProvider.idForDevice(device));
+
+                        return _DeviceTile(
+                          device: device,
+                          selected: selected,
+                          onUpdate: () async {
+                            onUpdate();
+                          },
+                        );
+                      },
                     );
-                  }
-
-                  index--;
-                  final device = devices[index];
-                  if (!this
-                      .events
-                      .keys
-                      .contains(EventsProvider.idForDevice(device))) {
-                    return const SizedBox.shrink();
-                  }
-
-                  final selected = events.selectedIds
-                      .contains(EventsProvider.idForDevice(device));
-
-                  return _DeviceTile(
-                    device: device,
-                    selected: selected,
-                    onUpdate: () async {
-                      onUpdate();
-                    },
-                  );
-                },
-              );
-            },
-          ),
+                  },
+                ),
         ),
       ]),
     );

--- a/lib/widgets/events_playback/events_playback_mobile.dart
+++ b/lib/widgets/events_playback/events_playback_mobile.dart
@@ -20,6 +20,7 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:bluecherry_client/models/device.dart';
 import 'package:bluecherry_client/providers/events_playback_provider.dart';
+import 'package:bluecherry_client/providers/server_provider.dart';
 import 'package:bluecherry_client/utils/extensions.dart';
 import 'package:bluecherry_client/utils/theme.dart';
 import 'package:bluecherry_client/widgets/device_grid/device_grid.dart';
@@ -48,8 +49,13 @@ class EventsPlaybackMobile extends EventsPlaybackWidget {
 class _EventsPlaybackMobileState extends EventsPlaybackState {
   @override
   Widget buildChild(BuildContext context) {
-    final eventsProvider = context.watch<EventsProvider>();
+    final serversProvider = context.watch<ServersProvider>();
 
+    final servers = serversProvider.servers.where((server) => server.devices
+        .any(
+            (d) => widget.events.keys.contains(EventsProvider.idForDevice(d))));
+
+    final eventsProvider = context.watch<EventsProvider>();
     final minTimelineHeight = kTimelineTileHeight *
         // at least the height of 2
         timelineController.tiles.length.clamp(
@@ -201,10 +207,16 @@ class _EventsPlaybackMobileState extends EventsPlaybackState {
             minWidth: double.infinity,
           ),
           child: Material(
-            child: TimelineView(
-              timelineController: timelineController,
-              showDevicesName: false,
-            ),
+            child: servers.isEmpty
+                ? Center(
+                    child: Text(
+                      AppLocalizations.of(context).noServersAvailable,
+                    ),
+                  )
+                : TimelineView(
+                    timelineController: timelineController,
+                    showDevicesName: false,
+                  ),
           ),
         ),
       ),

--- a/lib/widgets/misc.dart
+++ b/lib/widgets/misc.dart
@@ -195,6 +195,7 @@ class CorrectedListTile extends StatelessWidget {
 class SubHeader extends StatelessWidget {
   final String text;
   final String? subtext;
+  final TextStyle? subtextStyle;
   final EdgeInsetsGeometry padding;
   final double? height;
 
@@ -203,6 +204,7 @@ class SubHeader extends StatelessWidget {
   const SubHeader(
     this.text, {
     this.subtext,
+    this.subtextStyle,
     this.trailing,
     Key? key,
     this.padding = const EdgeInsets.symmetric(horizontal: 16.0),
@@ -232,11 +234,15 @@ class SubHeader extends StatelessWidget {
               if (subtext != null)
                 Text(
                   subtext!.toUpperCase(),
-                  style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                  style: Theme.of(context)
+                      .textTheme
+                      .labelSmall
+                      ?.copyWith(
                         color: Theme.of(context).hintColor,
                         fontSize: 10.0,
                         fontWeight: FontWeight.w600,
-                      ),
+                      )
+                      .merge(subtextStyle),
                 )
             ],
           ),

--- a/lib/widgets/settings/server_tile.dart
+++ b/lib/widgets/settings/server_tile.dart
@@ -224,57 +224,61 @@ class ServerCard extends StatelessWidget {
 
     final isLoading = servers.isServerLoading(server);
 
+    final loc = AppLocalizations.of(context);
+
     return SizedBox(
       height: 180,
       width: 180,
       child: Card(
         child: Stack(children: [
           Positioned.fill(
-            child: Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  CircleAvatar(
-                    backgroundColor: Colors.transparent,
-                    foregroundColor: Theme.of(context).iconTheme.color,
-                    child: const Icon(Icons.dns, size: 30.0),
-                  ),
-                  const SizedBox(height: 8.0),
-                  Text(
-                    server.name,
-                    overflow: TextOverflow.ellipsis,
-                    style: theme.textTheme.titleSmall,
-                  ),
-                  Text(
-                    !isLoading
-                        ? [
-                            if (server.name != server.ip) server.ip,
-                          ].join()
-                        : AppLocalizations.of(context).gettingDevices,
-                    overflow: TextOverflow.ellipsis,
-                    style: theme.textTheme.bodySmall,
-                  ),
-                  Text(
-                    !isLoading
-                        ? AppLocalizations.of(context)
-                            .nDevices(server.devices.length)
-                        : '',
-                  ),
-                  const SizedBox(height: 15.0),
-                  Transform.scale(
-                    scale: 0.9,
-                    child: OutlinedButton(
-                      child:
-                          Text(AppLocalizations.of(context).disconnectServer),
-                      onPressed: () {
-                        onRemoveServer(context, server);
-                      },
-                    ),
-                  ),
-                ],
+            bottom: 8.0,
+            left: 8.0,
+            right: 8.0,
+            top: 8.0,
+            child:
+                Column(mainAxisAlignment: MainAxisAlignment.center, children: [
+              CircleAvatar(
+                backgroundColor: Colors.transparent,
+                foregroundColor: theme.iconTheme.color,
+                child: const Icon(Icons.dns, size: 30.0),
               ),
-            ),
+              const SizedBox(height: 8.0),
+              Text(
+                server.name,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.titleSmall,
+              ),
+              Text(
+                !isLoading
+                    ? [
+                        if (server.name != server.ip) server.ip,
+                      ].join()
+                    : loc.gettingDevices,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodySmall,
+              ),
+              Text(
+                !server.online
+                    ? loc.offline
+                    : !isLoading
+                        ? loc.nDevices(server.devices.length)
+                        : '',
+                style: TextStyle(
+                  color: !server.online ? theme.colorScheme.error : null,
+                ),
+              ),
+              const SizedBox(height: 15.0),
+              Transform.scale(
+                scale: 0.9,
+                child: OutlinedButton(
+                  child: Text(loc.disconnectServer),
+                  onPressed: () {
+                    onRemoveServer(context, server);
+                  },
+                ),
+              ),
+            ]),
           ),
           PositionedDirectional(
             top: 4,
@@ -285,11 +289,11 @@ class ServerCard extends StatelessWidget {
               position: PopupMenuPosition.under,
               offset: const Offset(-128, 4.0),
               constraints: const BoxConstraints(maxWidth: 180.0),
-              tooltip: AppLocalizations.of(context).serverOptions,
+              tooltip: loc.serverOptions,
               itemBuilder: (context) {
                 return [
                   PopupMenuItem(
-                    child: Text(AppLocalizations.of(context).editServerInfo),
+                    child: Text(loc.editServerInfo),
                     onTap: () {
                       WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
                         if (context.mounted) showEditServer(context, server);
@@ -297,7 +301,7 @@ class ServerCard extends StatelessWidget {
                     },
                   ),
                   PopupMenuItem(
-                    child: Text(AppLocalizations.of(context).disconnectServer),
+                    child: Text(loc.disconnectServer),
                     onTap: () {
                       WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
                         if (context.mounted) {
@@ -308,20 +312,20 @@ class ServerCard extends StatelessWidget {
                   ),
                   const PopupMenuDivider(height: 1.0),
                   PopupMenuItem(
-                    child: Text(AppLocalizations.of(context).browseEvents),
+                    child: Text(loc.browseEvents),
                     onTap: () {
                       home.setTab(UnityTab.eventsScreen.index, context);
                     },
                   ),
                   PopupMenuItem(
-                    child: Text(AppLocalizations.of(context).configureServer),
+                    child: Text(loc.configureServer),
                     onTap: () {
                       launchUrl(Uri.parse(server.ip));
                     },
                   ),
                   const PopupMenuDivider(height: 1.0),
                   PopupMenuItem(
-                    child: Text(AppLocalizations.of(context).refreshDevices),
+                    child: Text(loc.refreshDevices),
                     onTap: () async {
                       servers.refreshDevices([server.id]);
                     },

--- a/lib/widgets/settings/settings.dart
+++ b/lib/widgets/settings/settings.dart
@@ -19,7 +19,6 @@
 
 import 'dart:io';
 
-import 'package:bluecherry_client/api/api.dart';
 import 'package:bluecherry_client/models/server.dart';
 import 'package:bluecherry_client/providers/home_provider.dart';
 import 'package:bluecherry_client/providers/server_provider.dart';


### PR DESCRIPTION
1. Update the servers on app startup:
often, in some cases, the server has updated the cameras and the cache is stale. With this, all the added servers are updated on startup. This does not delay startup time and the changes are reflected into the app in real time as soon as the task is completed.

2. Added the "OFFLINE" label to servers that are not online
![Grid](https://user-images.githubusercontent.com/45696119/223782241-9e7e0b63-f114-407f-9cfc-f731094f0937.png) ![Grid Light mode](https://user-images.githubusercontent.com/45696119/223782279-e4854714-4a18-4468-a6d4-dc6c924abe66.png) ![Settings Server Card](https://user-images.githubusercontent.com/45696119/223785222-24869390-499d-4738-98b3-9727ef68298a.png)

The patches above fix #77 

3. Added the "No servers available" hint on the timeline view. Fixes #79
![TimelineView desktop](https://user-images.githubusercontent.com/45696119/223785446-6f65499a-6bc0-4da0-9a91-6aa957e2856e.png) 
![TimelineView mobile](https://user-images.githubusercontent.com/45696119/223787388-b810d490-13c0-4426-b6a9-bbacf40e270d.png)

### Minor updates
* Remove devices from desktop grid when server is removed;
* Events are fetched simultaneously (for both event list and event timeline)