### PR TITLE
Add a check for single camera server

### DIFF
--- a/lib/models/device.dart
+++ b/lib/models/device.dart
@@ -48,6 +48,17 @@ class Device {
     this.server,
   );
 
+  factory Device.fromServerJson(Map map, Server server) {
+    return Device(
+      map['device_name'],
+      'live/${map['id']}',
+      map['status'] == 'OK',
+      map['resolutionX'] == null ? null : int.parse(map['resolutionX']),
+      map['resolutionX'] == null ? null : int.parse(map['resolutionY']),
+      server,
+    );
+  }
+
   String get streamURL =>
       'rtsp://${server.login}:${server.password}@${server.ip}:${server.rtspPort}/$uri';
 

--- a/packages/unity_video_player/unity_video_player_media_kit/lib/unity_video_player_media_kit.dart
+++ b/packages/unity_video_player/unity_video_player_media_kit/lib/unity_video_player_media_kit.dart
@@ -146,19 +146,19 @@ class UnityVideoPlayerMediaKit extends UnityVideoPlayer {
   Stream<Duration> get onCurrentPosUpdate => mkPlayer.streams.position;
 
   @override
-  bool get isBuffering => mkPlayer.state.buffering;
+  bool get isBuffering => mkPlayer.state.isBuffering;
 
   @override
   bool get isSeekable => true;
 
   @override
-  Stream<bool> get onBufferStateUpdate => mkPlayer.streams.buffering;
+  Stream<bool> get onBufferStateUpdate => mkPlayer.streams.isBuffering;
 
   @override
-  bool get isPlaying => mkPlayer.state.playing;
+  bool get isPlaying => mkPlayer.state.isPlaying;
 
   @override
-  Stream<bool> get onPlayingStateUpdate => mkPlayer.streams.playing;
+  Stream<bool> get onPlayingStateUpdate => mkPlayer.streams.isPlaying;
 
   @override
   Future<void> setDataSource(String url, {bool autoPlay = true}) {
@@ -184,15 +184,13 @@ class UnityVideoPlayerMediaKit extends UnityVideoPlayer {
 
   // Volume in media kit goes from 0 to 100
   @override
-  Future<void> setVolume(double volume) async =>
-      mkPlayer.setVolume(volume * 100);
+  Future<void> setVolume(double volume) async => mkPlayer.volume = volume * 100;
 
   @override
   Future<double> get volume async => mkPlayer.state.volume / 100;
 
   @override
-  Future<void> setSpeed(double speed) async => mkPlayer.setRate(speed);
-
+  Future<void> setSpeed(double speed) async => mkPlayer.rate = speed;
   @override
   Future<void> seekTo(Duration position) async => await mkPlayer.seek(position);
 

--- a/packages/unity_video_player/unity_video_player_media_kit/pubspec.yaml
+++ b/packages/unity_video_player/unity_video_player_media_kit/pubspec.yaml
@@ -17,32 +17,32 @@ dependencies:
   media_kit:
     git:
       url: https://github.com/alexmercerind/media_kit.git
-      ref: 03d8a702d5c0600e94548fd68a6b71c1485a0e49
+      ref: c71d6725dafff4045ed66cd711b10a8f4069bf11
       path: media_kit/
   media_kit_native_event_loop:
     git:
       url: https://github.com/alexmercerind/media_kit.git
-      ref: 03d8a702d5c0600e94548fd68a6b71c1485a0e49
+      ref: c71d6725dafff4045ed66cd711b10a8f4069bf11
       path: media_kit_native_event_loop/
   media_kit_video:
     git:
       url: https://github.com/alexmercerind/media_kit.git
-      ref: 03d8a702d5c0600e94548fd68a6b71c1485a0e49
+      ref: c71d6725dafff4045ed66cd711b10a8f4069bf11
       path: media_kit_video/
   media_kit_libs_windows_video:
     git:
       url: https://github.com/alexmercerind/media_kit.git
-      ref: 03d8a702d5c0600e94548fd68a6b71c1485a0e49
+      ref: c71d6725dafff4045ed66cd711b10a8f4069bf11
       path: media_kit_libs_windows_video/
   media_kit_libs_linux:
     git:
       url: https://github.com/alexmercerind/media_kit.git
-      ref: 03d8a702d5c0600e94548fd68a6b71c1485a0e49
+      ref: c71d6725dafff4045ed66cd711b10a8f4069bf11
       path: media_kit_libs_linux/
   media_kit_libs_macos_video:
     git:
       url: https://github.com/alexmercerind/media_kit.git
-      ref: 03d8a702d5c0600e94548fd68a6b71c1485a0e49
+      ref: c71d6725dafff4045ed66cd711b10a8f4069bf11
       path: media_kit_libs_macos_video/
   unity_video_player_platform_interface:
     path: ../unity_video_player_platform_interface/

--- a/packages/unity_video_player/unity_video_player_media_kit/pubspec.yaml
+++ b/packages/unity_video_player/unity_video_player_media_kit/pubspec.yaml
@@ -17,33 +17,28 @@ dependencies:
   media_kit:
     git:
       url: https://github.com/alexmercerind/media_kit.git
-      ref: c71d6725dafff4045ed66cd711b10a8f4069bf11
+      ref: 618d78e495b5809191e23966c4932fb02a425ef3
       path: media_kit/
   media_kit_native_event_loop:
     git:
       url: https://github.com/alexmercerind/media_kit.git
-      ref: c71d6725dafff4045ed66cd711b10a8f4069bf11
+      ref: 618d78e495b5809191e23966c4932fb02a425ef3
       path: media_kit_native_event_loop/
   media_kit_video:
     git:
       url: https://github.com/alexmercerind/media_kit.git
-      ref: c71d6725dafff4045ed66cd711b10a8f4069bf11
+      ref: 618d78e495b5809191e23966c4932fb02a425ef3
       path: media_kit_video/
   media_kit_libs_windows_video:
     git:
       url: https://github.com/alexmercerind/media_kit.git
-      ref: c71d6725dafff4045ed66cd711b10a8f4069bf11
+      ref: 618d78e495b5809191e23966c4932fb02a425ef3
       path: media_kit_libs_windows_video/
   media_kit_libs_linux:
     git:
       url: https://github.com/alexmercerind/media_kit.git
-      ref: c71d6725dafff4045ed66cd711b10a8f4069bf11
+      ref: 618d78e495b5809191e23966c4932fb02a425ef3
       path: media_kit_libs_linux/
-  media_kit_libs_macos_video:
-    git:
-      url: https://github.com/alexmercerind/media_kit.git
-      ref: c71d6725dafff4045ed66cd711b10a8f4069bf11
-      path: media_kit_libs_macos_video/
   unity_video_player_platform_interface:
     path: ../unity_video_player_platform_interface/
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -395,8 +395,8 @@ packages:
     dependency: transitive
     description:
       path: media_kit
-      ref: "03d8a702d5c0600e94548fd68a6b71c1485a0e49"
-      resolved-ref: "03d8a702d5c0600e94548fd68a6b71c1485a0e49"
+      ref: "618d78e495b5809191e23966c4932fb02a425ef3"
+      resolved-ref: "618d78e495b5809191e23966c4932fb02a425ef3"
       url: "https://github.com/alexmercerind/media_kit.git"
     source: git
     version: "0.0.1"
@@ -404,17 +404,8 @@ packages:
     dependency: transitive
     description:
       path: media_kit_libs_linux
-      ref: "03d8a702d5c0600e94548fd68a6b71c1485a0e49"
-      resolved-ref: "03d8a702d5c0600e94548fd68a6b71c1485a0e49"
-      url: "https://github.com/alexmercerind/media_kit.git"
-    source: git
-    version: "1.0.0"
-  media_kit_libs_macos_video:
-    dependency: transitive
-    description:
-      path: media_kit_libs_macos_video
-      ref: "03d8a702d5c0600e94548fd68a6b71c1485a0e49"
-      resolved-ref: "03d8a702d5c0600e94548fd68a6b71c1485a0e49"
+      ref: "618d78e495b5809191e23966c4932fb02a425ef3"
+      resolved-ref: "618d78e495b5809191e23966c4932fb02a425ef3"
       url: "https://github.com/alexmercerind/media_kit.git"
     source: git
     version: "1.0.0"
@@ -422,8 +413,8 @@ packages:
     dependency: transitive
     description:
       path: media_kit_libs_windows_video
-      ref: "03d8a702d5c0600e94548fd68a6b71c1485a0e49"
-      resolved-ref: "03d8a702d5c0600e94548fd68a6b71c1485a0e49"
+      ref: "618d78e495b5809191e23966c4932fb02a425ef3"
+      resolved-ref: "618d78e495b5809191e23966c4932fb02a425ef3"
       url: "https://github.com/alexmercerind/media_kit.git"
     source: git
     version: "1.0.0"
@@ -431,20 +422,20 @@ packages:
     dependency: transitive
     description:
       path: media_kit_native_event_loop
-      ref: "03d8a702d5c0600e94548fd68a6b71c1485a0e49"
-      resolved-ref: "03d8a702d5c0600e94548fd68a6b71c1485a0e49"
+      ref: "618d78e495b5809191e23966c4932fb02a425ef3"
+      resolved-ref: "618d78e495b5809191e23966c4932fb02a425ef3"
       url: "https://github.com/alexmercerind/media_kit.git"
     source: git
-    version: "1.0.1"
+    version: "1.0.0"
   media_kit_video:
     dependency: transitive
     description:
       path: media_kit_video
-      ref: "03d8a702d5c0600e94548fd68a6b71c1485a0e49"
-      resolved-ref: "03d8a702d5c0600e94548fd68a6b71c1485a0e49"
+      ref: "618d78e495b5809191e23966c4932fb02a425ef3"
+      resolved-ref: "618d78e495b5809191e23966c4932fb02a425ef3"
       url: "https://github.com/alexmercerind/media_kit.git"
     source: git
-    version: "0.0.2"
+    version: "0.0.1"
   meta:
     dependency: transitive
     description:
@@ -638,7 +629,7 @@ packages:
     source: hosted
     version: "0.6.0"
   safe_local_storage:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: safe_local_storage
       sha256: "7ca14be87040e6badfcdb9c71e963846c4e7d827dbc9f62cab7496497352f8d8"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -865,10 +865,10 @@ packages:
     dependency: "direct main"
     description:
       name: window_manager
-      sha256: "5bdd29dc5f1f3185fc90696373a571d77968e03e5e820fb1ecdbdade3f5d8fff"
+      sha256: "492806c69879f0d28e95472bbe5e8d5940ac8c6e99cc07052fe14946974555ba"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.1"
   xdg_directories:
     dependency: transitive
     description:


### PR DESCRIPTION
When the server only has one camera, the server returns an object instead of a list. Previously, only a list of objects were taken into account. Now, if a single object is detected, the client handles it properly