### PR TITLE
Events limit

### DIFF
--- a/lib/api/api_helpers.dart
+++ b/lib/api/api_helpers.dart
@@ -85,7 +85,6 @@ abstract class APIHelpers {
   }) async {
     final events = await API.instance.getEvents(
       await API.instance.checkServerCredentials(server),
-      limit: attempts,
     );
     debugPrint(events.map((e) => e.id).toList().toString());
     Future<String?> getThumbnailForMediaID(int mediaID) async {

--- a/lib/firebase_messaging_background_handler.dart
+++ b/lib/firebase_messaging_background_handler.dart
@@ -256,7 +256,7 @@ Future<void> _backgroundClickAction(ReceivedAction action) async {
         _mutex = 'events_screen';
         await navigatorKey.currentState?.push(
           MaterialPageRoute(
-            builder: (context) => const EventsScreen(),
+            builder: (context) => EventsScreen(key: eventsScreenKey),
           ),
         );
         _mutex = null;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -203,7 +203,7 @@ class UnityApp extends StatelessWidget {
             if (settings.name == '/events') {
               final data = settings.arguments! as Map;
               final event = data['event'] as Event;
-              final upcomingEvents = data['upcoming'] as List<Event>;
+              final upcomingEvents = data['upcoming'] as Iterable<Event>;
 
               return MaterialPageRoute(
                 settings: RouteSettings(

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -64,3 +64,6 @@ const uuid = Uuid();
 
 /// If the screen size is smaller or equal to this, a mobile view shall be used
 const kMobileBreakpoint = Size(800, 500);
+
+/// The amount of events to load at once
+const kEventsLimit = 1000;

--- a/lib/widgets/desktop_buttons.dart
+++ b/lib/widgets/desktop_buttons.dart
@@ -201,7 +201,7 @@ class _WindowButtonsState extends State<WindowButtons> with WindowListener {
                     padding: EdgeInsets.symmetric(horizontal: 8.0),
                     child: UnityLoadingIndicator(),
                   )
-                else if (home.tab == UnityTab.eventsScreen.index)
+                else if (home.tab == UnityTab.eventsScreen.index && !canPop)
                   IconButton(
                     onPressed: () {
                       eventsScreenKey.currentState?.fetch();

--- a/lib/widgets/desktop_buttons.dart
+++ b/lib/widgets/desktop_buttons.dart
@@ -24,9 +24,11 @@ import 'package:bluecherry_client/main.dart';
 import 'package:bluecherry_client/models/device.dart';
 import 'package:bluecherry_client/models/event.dart';
 import 'package:bluecherry_client/providers/home_provider.dart';
+import 'package:bluecherry_client/widgets/events/events_screen.dart';
 import 'package:bluecherry_client/widgets/home.dart';
 import 'package:bluecherry_client/widgets/misc.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 import 'package:unity_video_player/unity_video_player.dart';
 import 'package:window_manager/window_manager.dart';
@@ -113,6 +115,7 @@ class _WindowButtonsState extends State<WindowButtons> with WindowListener {
     if (!isDesktop || isMobile) return const SizedBox.shrink();
 
     final theme = Theme.of(context);
+    final loc = AppLocalizations.of(context);
 
     final home = context.watch<HomeProvider>();
     final tab = home.tab;
@@ -197,6 +200,15 @@ class _WindowButtonsState extends State<WindowButtons> with WindowListener {
                   const Padding(
                     padding: EdgeInsets.symmetric(horizontal: 8.0),
                     child: UnityLoadingIndicator(),
+                  )
+                else if (home.tab == UnityTab.eventsScreen.index)
+                  IconButton(
+                    onPressed: () {
+                      eventsScreenKey.currentState?.fetch();
+                    },
+                    icon: const Icon(Icons.refresh),
+                    iconSize: 20.0,
+                    tooltip: loc.refresh,
                   ),
                 SizedBox(
                   width: 138,

--- a/lib/widgets/events/event_player_desktop.dart
+++ b/lib/widgets/events/event_player_desktop.dart
@@ -41,7 +41,7 @@ const kSliderControlerWidth = 100.0;
 class EventPlayerDesktop extends StatefulWidget {
   final Event event;
 
-  final List<Event> upcomingEvents;
+  final Iterable<Event> upcomingEvents;
 
   const EventPlayerDesktop({
     super.key,

--- a/lib/widgets/events/event_player_mobile.dart
+++ b/lib/widgets/events/event_player_mobile.dart
@@ -21,7 +21,7 @@ part of 'events_screen.dart';
 
 class EventPlayerScreen extends StatelessWidget {
   final Event event;
-  final List<Event> upcomingEvents;
+  final Iterable<Event> upcomingEvents;
 
   const EventPlayerScreen({
     super.key,

--- a/lib/widgets/events/events_screen.dart
+++ b/lib/widgets/events/events_screen.dart
@@ -212,6 +212,14 @@ class _EventsScreenState extends State<EventsScreen> {
             leading: MaybeUnityDrawerButton(context),
             title: Text(loc.eventBrowser),
             actions: [
+              IconButton(
+                onPressed: () {
+                  eventsScreenKey.currentState?.fetch();
+                },
+                icon: const Icon(Icons.refresh),
+                iconSize: 20.0,
+                tooltip: loc.refresh,
+              ),
               Padding(
                 padding: const EdgeInsetsDirectional.only(end: 15.0),
                 child: IconButton(
@@ -242,10 +250,7 @@ class _EventsScreenState extends State<EventsScreen> {
             shape: const RoundedRectangleBorder(),
             child: DropdownButtonHideUnderline(
               child: Column(children: [
-                SubHeader(
-                  loc.servers,
-                  height: 40.0,
-                ),
+                SubHeader(loc.servers, height: 40.0),
                 Expanded(
                   child: SingleChildScrollView(
                     child: buildTreeView(context, setState: setState),

--- a/lib/widgets/events/events_screen.dart
+++ b/lib/widgets/events/events_screen.dart
@@ -349,6 +349,7 @@ class _EventsScreenState extends State<EventsScreen> {
         final isTriState = disabledDevices
             .any((d) => server.devices.any((device) => device.rtspURL == d));
         final isOffline = !server.online;
+        final serverEvents = events[server];
 
         return TreeNode(
           content: Row(children: [
@@ -396,6 +397,8 @@ class _EventsScreenState extends State<EventsScreen> {
                 final enabled = isOffline || !allowedServers.contains(server)
                     ? false
                     : !disabledDevices.contains(device.rtspURL);
+                final eventsForDevice =
+                    serverEvents?.where((event) => event.deviceID == device.id);
                 return TreeNode(
                   content: Row(children: [
                     IgnorePointer(
@@ -418,12 +421,21 @@ class _EventsScreenState extends State<EventsScreen> {
                       ),
                     ),
                     SizedBox(width: gapCheckboxText),
-                    Text(
-                      device.name,
-                      overflow: TextOverflow.ellipsis,
-                      maxLines: 1,
-                      softWrap: false,
+                    Flexible(
+                      child: Text(
+                        device.name,
+                        overflow: TextOverflow.ellipsis,
+                        maxLines: 1,
+                        softWrap: false,
+                      ),
                     ),
+                    if (eventsForDevice != null) ...[
+                      Text(
+                        ' (${eventsForDevice.length})',
+                        style: theme.textTheme.labelSmall,
+                      ),
+                      const SizedBox(width: 10.0),
+                    ],
                   ]),
                 );
               }).toList();

--- a/lib/widgets/events/events_screen.dart
+++ b/lib/widgets/events/events_screen.dart
@@ -49,10 +49,12 @@ part 'event_player_mobile.dart';
 part 'events_screen_desktop.dart';
 part 'events_screen_mobile.dart';
 
-typedef EventsData = Map<Server, List<Event>>;
+typedef EventsData = Map<Server, Iterable<Event>>;
+
+final eventsScreenKey = GlobalKey<_EventsScreenState>();
 
 class EventsScreen extends StatefulWidget {
-  const EventsScreen({super.key});
+  const EventsScreen({required super.key});
 
   @override
   State<EventsScreen> createState() => _EventsScreenState();
@@ -67,7 +69,7 @@ class _EventsScreenState extends State<EventsScreen> {
   final EventsData events = {};
   Map<Server, bool> invalid = {};
 
-  List<Event> filteredEvents = [];
+  Iterable<Event> filteredEvents = [];
 
   /// The devices that can't be displayed in the list
   List<String> disabledDevices = [];
@@ -92,7 +94,7 @@ class _EventsScreenState extends State<EventsScreen> {
           );
           if (mounted) {
             setState(() {
-              events[server] = iterable.toList();
+              events[server] = iterable;
               invalid[server] = false;
             });
           }
@@ -127,7 +129,7 @@ class _EventsScreenState extends State<EventsScreen> {
     });
   }
 
-  static List<Event> _updateFiltered(Map<String, dynamic> data) {
+  static Iterable<Event> _updateFiltered(Map<String, dynamic> data) {
     final events = data['events'] as EventsData;
     final allowedServers = data['allowedServers'] as List<Server>;
     final timeFilter = data['timeFilter'] as EventsTimeFilter;
@@ -178,7 +180,7 @@ class _EventsScreenState extends State<EventsScreen> {
 
         yield event;
       }
-    }).toList();
+    });
   }
 
   /// We override setState because we need to update the filtered events

--- a/lib/widgets/events/events_screen.dart
+++ b/lib/widgets/events/events_screen.dart
@@ -84,6 +84,8 @@ class _EventsScreenState extends State<EventsScreen> {
     try {
       // Load the events at the same time
       await Future.wait(ServersProvider.instance.servers.map((server) async {
+        if (!server.online) return;
+
         try {
           final iterable = await API.instance.getEvents(
             await API.instance.checkServerCredentials(server),
@@ -184,8 +186,11 @@ class _EventsScreenState extends State<EventsScreen> {
   void setState(VoidCallback fn) {
     super.setState(fn);
     // computes the events based on the filter, then update the screen
+    final home = context.read<HomeProvider>()
+      ..loading(UnityLoadingReason.fetchingEventsHistory);
     computeFiltered().then((_) {
       if (mounted) super.setState(() {});
+      home.notLoading(UnityLoadingReason.fetchingEventsHistory);
     });
   }
 

--- a/lib/widgets/events/events_screen_desktop.dart
+++ b/lib/widgets/events/events_screen_desktop.dart
@@ -19,14 +19,20 @@
 
 part of 'events_screen.dart';
 
-Widget _buildTilePart({required Widget child, int flex = 1}) {
+Widget _buildTilePart({required Widget child, Widget? icon, int flex = 1}) {
   return Expanded(
     flex: flex,
     child: Container(
       height: 40.0,
       margin: const EdgeInsetsDirectional.only(start: 10.0),
       alignment: AlignmentDirectional.centerStart,
-      child: child,
+      child: Row(children: [
+        if (icon != null) ...[
+          IconTheme.merge(data: const IconThemeData(size: 14.0), child: icon),
+          const SizedBox(width: 6.0),
+        ],
+        Flexible(child: child),
+      ]),
     ),
   );
 }
@@ -128,23 +134,29 @@ class _TableHeader extends SliverPersistentHeaderDelegate {
             child: Row(children: [
               const SizedBox(width: 40.0, height: 40.0),
               _buildTilePart(
+                icon: const Icon(Icons.dns),
                 child: Text(loc.server),
                 flex: 2,
               ),
               _buildTilePart(
                 child: Text(loc.device),
+                icon: const Icon(Icons.camera),
               ),
               _buildTilePart(
                 child: Text(loc.event),
+                icon: const Icon(Icons.subscriptions),
               ),
               _buildTilePart(
                 child: Text(loc.duration),
+                icon: const Icon(Icons.timer),
               ),
               _buildTilePart(
                 child: Text(loc.priority),
+                icon: const Icon(Icons.priority_high),
               ),
               _buildTilePart(
                 child: Text(loc.date),
+                icon: const Icon(Icons.calendar_today),
                 flex: 2,
               ),
             ]),

--- a/lib/widgets/events/events_screen_desktop.dart
+++ b/lib/widgets/events/events_screen_desktop.dart
@@ -56,7 +56,8 @@ class EventsScreenDesktop extends StatelessWidget {
           ],
           showCheckboxColumn: false,
           rows: events.map<DataRow>((Event event) {
-            final index = events.indexOf(event);
+            // final index = events.indexOf(event);
+            final index = event.id;
 
             return DataRow(
               key: ValueKey<Event>(event),

--- a/lib/widgets/events/events_screen_desktop.dart
+++ b/lib/widgets/events/events_screen_desktop.dart
@@ -20,7 +20,7 @@
 part of 'events_screen.dart';
 
 class EventsScreenDesktop extends StatelessWidget {
-  final List<Event> events;
+  final Iterable<Event> events;
 
   const EventsScreenDesktop({super.key, required this.events});
 

--- a/lib/widgets/events/events_screen_mobile.dart
+++ b/lib/widgets/events/events_screen_mobile.dart
@@ -86,10 +86,11 @@ class EventsScreenMobile extends StatelessWidget {
                         loc.offline,
                         style: TextStyle(
                           color: theme.colorScheme.error,
+                          fontWeight: FontWeight.w600,
                         ),
                       )
                     : Text(
-                        '${loc.nDevices(server.devices.length)} • ${server.ip}',
+                        '${loc.nDevices(server.devices.length)} • ${server.ip}  • ${serverEvents.length} events',
                       ),
                 children: !hasEvents
                     ? [

--- a/lib/widgets/home.dart
+++ b/lib/widgets/home.dart
@@ -154,7 +154,9 @@ class _MobileHomeState extends State<Home> {
                         return const DirectCameraScreen();
                       },
                       UnityTab.eventsPlayback: () => const EventsPlayback(),
-                      UnityTab.eventsScreen: () => const EventsScreen(),
+                      UnityTab.eventsScreen: () => EventsScreen(
+                            key: eventsScreenKey,
+                          ),
                       UnityTab.addServer: () => AddServerWizard(
                             onFinish: () async => home.setTab(0, context),
                           ),

--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -31,6 +31,11 @@ bool FlutterWindow::OnCreate() {
     this->Show();
   });
 
+  // Flutter can complete the first frame before the "show window" callback is
+  // registered. The following call ensures a frame is pending to ensure the
+  // window is shown. It is a no-op if the first frame hasn't completed yet.
+  flutter_controller_->ForceRedraw();
+
   return true;
 }
 


### PR DESCRIPTION
* Events are requested and parsed from the server in another thread  (Fixes #113)
* Added a Refresh button
* Filtering logic has been moved outside of the UI thread
* The events list is now rendered with lazy loading and fixed item extent, which skips some calculation from the framework
* [ui] The table header is now pinned to the top

