### PR TITLE
fix: add camera to view

### DIFF
--- a/lib/providers/desktop_view_provider.dart
+++ b/lib/providers/desktop_view_provider.dart
@@ -38,7 +38,9 @@ class DesktopViewProvider extends ChangeNotifier {
     return instance;
   }
 
-  List<Layout> layouts = [const Layout(name: 'Default')];
+  List<Layout> layouts = [
+    Layout(name: 'Default', devices: List.empty(growable: true)),
+  ];
   int _currentLayout = 0;
   int get currentLayoutIndex {
     if (_currentLayout.isNegative) return 0;

--- a/lib/utils/storage.dart
+++ b/lib/utils/storage.dart
@@ -1,4 +1,5 @@
 import 'package:bluecherry_client/utils/constants.dart';
+import 'package:flutter/foundation.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
@@ -6,6 +7,8 @@ import 'package:safe_local_storage/safe_local_storage.dart';
 
 Future<void> configureStorage() async {
   final dir = (await getApplicationSupportDirectory()).path;
+
+  debugPrint('App working directory: $dir');
 
   storage = SafeLocalStorage(path.join(dir, 'bluecherry.json'));
   settings = SafeLocalStorage(path.join(dir, 'settings.json'));

--- a/lib/widgets/device_grid/desktop/desktop_device_grid.dart
+++ b/lib/widgets/device_grid/desktop/desktop_device_grid.dart
@@ -378,7 +378,10 @@ class _DesktopTileViewportState extends State<DesktopTileViewport> {
             child: RichText(
               text: TextSpan(
                 text: widget.device.name,
-                style: theme.textTheme.labelLarge,
+                style: theme.textTheme.labelLarge?.copyWith(
+                  color: Colors.white,
+                  shadows: outlinedText(),
+                ),
                 children: [
                   if (states.isHovering)
                     TextSpan(
@@ -548,13 +551,7 @@ class _DesktopTileViewportState extends State<DesktopTileViewport> {
                 duration: const Duration(milliseconds: 200),
                 curve: Curves.easeInOut,
                 child: IconButton(
-                  icon: Icon(
-                    Icons.close_outlined,
-                    shadows: outlinedText(
-                      strokeColor: theme.colorScheme.errorContainer,
-                      strokeWidth: 0.15,
-                    ),
-                  ),
+                  icon: const Icon(Icons.close_outlined),
                   color: theme.colorScheme.error,
                   tooltip: loc.removeCamera,
                   iconSize: 18.0,

--- a/lib/widgets/device_grid/desktop/desktop_sidebar.dart
+++ b/lib/widgets/device_grid/desktop/desktop_sidebar.dart
@@ -255,6 +255,7 @@ class _DesktopDeviceSelectorTileState extends State<DesktopDeviceSelectorTile> {
   Future<void> _displayOptions(BuildContext context) async {
     if (!widget.device.status) return;
 
+    final theme = Theme.of(context);
     final loc = AppLocalizations.of(context);
     final view = context.read<DesktopViewProvider>();
 
@@ -284,6 +285,17 @@ class _DesktopDeviceSelectorTileState extends State<DesktopDeviceSelectorTile> {
         minWidth: size.width,
       ),
       items: <PopupMenuEntry>[
+        PopupLabel(
+          label: Padding(
+            padding: padding.add(const EdgeInsets.symmetric(vertical: 6.0)),
+            child: Text(
+              widget.device.name,
+              maxLines: 1,
+              style: theme.textTheme.labelSmall,
+            ),
+          ),
+        ),
+        const PopupMenuDivider(),
         PopupMenuItem(
           child: Text(
             widget.selected ? loc.removeFromView : loc.addToView,
@@ -296,7 +308,6 @@ class _DesktopDeviceSelectorTileState extends State<DesktopDeviceSelectorTile> {
             }
           },
         ),
-        const PopupMenuDivider(height: 8),
         PopupMenuItem(
           child: Text(
             loc.showFullscreenCamera,

--- a/lib/widgets/device_grid/desktop/layout_manager.dart
+++ b/lib/widgets/device_grid/desktop/layout_manager.dart
@@ -193,7 +193,6 @@ class LayoutTile extends StatelessWidget {
               ),
             ),
           ),
-          horizontalTitleGap: 16.0,
           minLeadingWidth: 24.0,
           title: Text(layout.name, maxLines: 1),
           subtitle: Text(
@@ -201,10 +200,14 @@ class LayoutTile extends StatelessWidget {
             maxLines: 1,
           ),
           trailing: states.isHovering
-              ? InkWell(
-                  borderRadius: BorderRadius.circular(4.0),
-                  onTap: () => _displayOptions(context),
-                  child: Icon(moreIconData),
+              ? Tooltip(
+                  message: loc.cameraOptions,
+                  preferBelow: false,
+                  child: InkWell(
+                    borderRadius: BorderRadius.circular(4.0),
+                    onTap: () => _displayOptions(context),
+                    child: Icon(moreIconData),
+                  ),
                 )
               : null,
           onTap: !selected


### PR DESCRIPTION
Follow up of #121

The default layout, on the first app run, crashed the app if a device was added. The layout is no longer initialized with a constant list of devices, allowing it to be added properly