### PR TITLE
fix: events parsing from the server

### DIFF
--- a/lib/api/events.dart
+++ b/lib/api/events.dart
@@ -1,0 +1,142 @@
+import 'dart:convert';
+
+import 'package:bluecherry_client/api/api.dart';
+import 'package:bluecherry_client/api/api_helpers.dart';
+import 'package:bluecherry_client/models/event.dart';
+import 'package:bluecherry_client/models/server.dart';
+import 'package:bluecherry_client/utils/constants.dart';
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:xml2json/xml2json.dart';
+
+extension EventsExtension on API {
+  /// Gets the [Event]s present on the [server].
+  ///
+  /// If server is offline, then it returns an empty list.
+  Future<Iterable<Event>> getEvents(Server server) async {
+    if (!server.online) {
+      debugPrint('Can not get events of an offline server: $server');
+      return [];
+    }
+
+    return compute(_getEvents, server);
+  }
+
+  static Future<Iterable<Event>> _getEvents(Server server) async {
+    if (!server.online) {
+      debugPrint('Can not get events of an offline server: $server');
+      return [];
+    }
+
+    DevHttpOverrides.configureCertificates();
+
+    assert(server.serverUUID != null && server.cookie != null);
+    final response = await http.get(
+      Uri.https(
+        '${Uri.encodeComponent(server.login)}:${Uri.encodeComponent(server.password)}@${server.ip}:${server.port}',
+        '/events/',
+        {
+          'XML': '1',
+          'limit': '$kEventsLimit',
+        },
+      ),
+      headers: {
+        'Cookie': server.cookie!,
+      },
+    );
+
+    Iterable<Event> events = <Event>[];
+
+    try {
+      debugPrint('Getting events for server ${server.name}');
+
+      final parser = Xml2Json()..parse(response.body);
+      events = (jsonDecode(parser.toGData())['feed']['entry'] as List)
+          .map((e) {
+            if (!e.containsKey('content')) debugPrint(e.toString());
+            return Event(
+              server,
+              int.parse(e['id']['raw']),
+              int.parse((e['category']['term'] as String).split('/').first),
+              e['title']['\$t'],
+              e['published'] == null || e['published']['\$t'] == null
+                  ? DateTime.now()
+                  : DateTime.parse(e['published']['\$t']).toLocal(),
+              e['updated'] == null || e['updated']['\$t'] == null
+                  ? DateTime.now()
+                  : DateTime.parse(e['updated']['\$t']).toLocal(),
+              e['category']['term'],
+              !e.containsKey('content')
+                  ? null
+                  : int.parse(e['content']['media_id']),
+              !e.containsKey('content')
+                  ? null
+                  : Uri.parse(
+                      e['content'][r'$t'].replaceAll(
+                        'https://',
+                        'https://${Uri.encodeComponent(server.login)}:${Uri.encodeComponent(server.password)}@',
+                      ),
+                    ),
+            );
+          })
+          .where((e) => e.duration > const Duration(minutes: 1))
+          .cast<Event>();
+    } on Xml2JsonException {
+      debugPrint('Failed to parse XML response from server ${server.name}');
+      debugPrint('Attempting to parse using JSON');
+
+      events = ((jsonDecode(response.body) as Map)['entry'] as List)
+          .cast<Map>()
+          .map((eventObject) {
+        final published = DateTime.parse(eventObject['published']).toLocal();
+        final event = Event.factory(
+          server: server,
+          id: () {
+            final idObject = eventObject['id'].toString();
+
+            if (int.tryParse(idObject) != null) {
+              return int.parse(idObject);
+            }
+
+            final parts = idObject.split('id=');
+            if (parts.isEmpty) {
+              return -1;
+            }
+
+            return int.parse(parts.last);
+          }(),
+          deviceID: int.parse(
+            (eventObject['category']['term'] as String?)?.split('/').first ??
+                '-1',
+          ),
+          title: eventObject['title'],
+          published: published,
+          updated: eventObject['updated'] == null
+              ? published
+              : DateTime.parse(eventObject['updated']).toLocal(),
+          category: eventObject['category']['term'],
+          mediaID: eventObject.containsKey('content')
+              ? int.parse(eventObject['content']['media_id'])
+              : null,
+          mediaURL: eventObject.containsKey('content')
+              ? Uri.parse(
+                  (eventObject['content']['content'] as String).replaceAll(
+                    'https://',
+                    'https://${Uri.encodeComponent(server.login)}:${Uri.encodeComponent(server.password)}@',
+                  ),
+                )
+              : null,
+        );
+        return event;
+      });
+    } catch (exception, stacktrace) {
+      debugPrint('Failed to getEvents on server ${server.name}');
+      debugPrint(exception.toString());
+      debugPrint(stacktrace.toString());
+    }
+
+    debugPrint('Loaded ${events.length} events for server ${server.name}');
+
+    return events;
+  }
+}

--- a/lib/models/event.dart
+++ b/lib/models/event.dart
@@ -47,6 +47,18 @@ class Event {
     this.mediaURL,
   );
 
+  const Event.factory({
+    required this.server,
+    required this.id,
+    required this.deviceID,
+    required this.title,
+    required this.published,
+    required this.updated,
+    required this.category,
+    required this.mediaID,
+    required this.mediaURL,
+  });
+
   Event.dump({
     Server? server,
     this.id = 1,

--- a/lib/widgets/events_timeline/desktop/timeline_sidebar.dart
+++ b/lib/widgets/events_timeline/desktop/timeline_sidebar.dart
@@ -146,7 +146,7 @@ class _TimelineSidebarState extends State<TimelineSidebar> {
                     widget.timeline.add([
                       state.realDevices.entries
                           .firstWhere((e) => e.key == device)
-                          .buildTimelineTile(),
+                          .buildTimelineTile(context),
                     ]);
                   }
                 }
@@ -202,7 +202,7 @@ class _TimelineSidebarState extends State<TimelineSidebar> {
                             widget.timeline.add([
                               state.realDevices.entries
                                   .firstWhere((e) => e.key == device)
-                                  .buildTimelineTile(),
+                                  .buildTimelineTile(context),
                             ]);
                           }
                           setState(() {});

--- a/lib/widgets/events_timeline/mobile/timeline_device_view.dart
+++ b/lib/widgets/events_timeline/mobile/timeline_device_view.dart
@@ -316,7 +316,7 @@ class _TimelineDeviceViewState extends State<TimelineDeviceView> {
             }
 
             return UnityVideoView(
-              heroTag: currentEvent!.event.mediaURL,
+              heroTag: currentEvent!.videoUrl,
               player: tile.videoController,
               paneBuilder: !kDebugMode
                   ? null

--- a/lib/widgets/ptz.dart
+++ b/lib/widgets/ptz.dart
@@ -18,7 +18,6 @@
  */
 
 import 'package:bluecherry_client/api/api.dart';
-import 'package:bluecherry_client/api/ptz.dart';
 import 'package:bluecherry_client/models/device.dart';
 import 'package:bluecherry_client/widgets/hover_button.dart';
 import 'package:flutter/material.dart';


### PR DESCRIPTION
New versions of the server returns a JSON on the `/getEvents` endpoint.

This patch fallbacks to json decoder in case of the XML decoder fails. This way we keep backwards compatibility