### PR TITLE
Addressings

### DIFF
--- a/lib/api/api_helpers.dart
+++ b/lib/api/api_helpers.dart
@@ -66,10 +66,13 @@ abstract class APIHelpers {
 
   /// Converts [eventID] into human-readable string.
   /// Used by notification handler.
-  static String getEventNameFromID(String eventID) => {
-        'device_state': 'Device State Event',
-        'motion_event': 'Motion Event',
-      }[eventID]!;
+  static String getEventNameFromID(String eventID) {
+    return switch (eventID) {
+      'device_state' => 'Device State Event',
+      'motion_event' => 'Motion Event',
+      _ => 'Event',
+    };
+  }
 
   /// Returns the [File] path of the thumbnail downloaded for a [deviceID] from the [server].
   /// Returns `null` & [File] could not be fetched i.e. screenshot does not exist on the server.

--- a/lib/api/events.dart
+++ b/lib/api/events.dart
@@ -40,9 +40,7 @@ extension EventsExtension on API {
         '/events/',
         {'XML': '1', 'limit': '$limit'},
       ),
-      headers: {
-        'Cookie': server.cookie!,
-      },
+      headers: {'Cookie': server.cookie!},
     );
 
     var events = const Iterable<Event>.empty();
@@ -62,10 +60,10 @@ extension EventsExtension on API {
               e['title']['\$t'],
               e['published'] == null || e['published']['\$t'] == null
                   ? DateTime.now()
-                  : DateTime.parse(e['published']['\$t']).toLocal(),
+                  : DateTime.parse(e['published']['\$t']),
               e['updated'] == null || e['updated']['\$t'] == null
                   ? DateTime.now()
-                  : DateTime.parse(e['updated']['\$t']).toLocal(),
+                  : DateTime.parse(e['updated']['\$t']),
               e['category']['term'],
               !e.containsKey('content')
                   ? null
@@ -89,7 +87,7 @@ extension EventsExtension on API {
       events = ((jsonDecode(response.body) as Map)['entry'] as Iterable)
           .cast<Map>()
           .map((eventObject) {
-        final published = DateTime.parse(eventObject['published']).toLocal();
+        final published = DateTime.parse(eventObject['published']);
         final event = Event.factory(
           server: server,
           id: () {
@@ -114,7 +112,7 @@ extension EventsExtension on API {
           published: published,
           updated: eventObject['updated'] == null
               ? published
-              : DateTime.parse(eventObject['updated']).toLocal(),
+              : DateTime.parse(eventObject['updated']),
           category: eventObject['category']['term'],
           mediaID: eventObject.containsKey('content')
               ? int.parse(eventObject['content']['media_id'])

--- a/lib/firebase_messaging_background_handler.dart
+++ b/lib/firebase_messaging_background_handler.dart
@@ -259,11 +259,12 @@ Future<void> _backgroundClickAction(ReceivedAction action) async {
   else {
     debugPrint('action.buttonKeyPressed.isNotEmpty');
     final duration = Duration(
-      minutes: {
-        'snooze_15': 15,
-        'snooze_30': 30,
-        'snooze_60': 60,
-      }[action.buttonKeyPressed]!,
+      minutes: switch (action.buttonKeyPressed) {
+        'snooze_15' => 15,
+        'snooze_30' => 30,
+        'snooze_60' => 60,
+        _ => 15,
+      },
     );
     debugPrint(DateTime.now().add(duration).toString());
     SettingsProvider.instance.snoozedUntil = DateTime.now().add(duration);

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -35,7 +35,7 @@
     }
   },
   "serverAdded": "Server has been added",
-  "serverNotAddedError": "{serverName} could not be added. Please check the entered details and check if the server is online.",
+  "serverNotAddedError": "{serverName} could not be added.",
   "@serverNotAddedError": {
     "placeholders": {
       "serverName": {
@@ -43,9 +43,11 @@
       }
     }
   },
+  "serverNotAddedErrorDescription": "Please check the entered details and ensure the server is online.\n\nIf you are connecting remote, make sure the 7001 and 7002 ports are open to the Bluecherry server!",
   "noServersAvailable": "No servers available",
   "error": "Error",
   "ok": "OK",
+  "retry": "Retry",
   "removeCamera": "Remove Camera",
   "replaceCamera": "Replace Camera",
   "reloadCamera": "Reload Camera",

--- a/lib/models/event.dart
+++ b/lib/models/event.dart
@@ -85,7 +85,7 @@ class Event {
 
   Duration get duration {
     final dur = updated.difference(published);
-    if (dur < Duration.zero) return updated.difference(published);
+    if (dur < Duration.zero) return published.difference(updated);
     return dur;
   }
 

--- a/lib/providers/desktop_view_provider.dart
+++ b/lib/providers/desktop_view_provider.dart
@@ -175,17 +175,6 @@ class DesktopViewProvider extends ChangeNotifier {
     return _save(notifyListeners: false);
   }
 
-  /// Reloads a camera [Device] tile from the camera grid, at specified [tab] [index].
-  /// e.g. in response to a network error etc.
-  Future<void> reload(Device device) async {
-    await UnityPlayers.players[device]?.reset();
-    await UnityPlayers.players[device]?.setDataSource(device.streamURL);
-    await UnityPlayers.players[device]?.setVolume(0.0);
-    await UnityPlayers.players[device]?.setSpeed(1.0);
-    notifyListeners();
-    return _save(notifyListeners: false);
-  }
-
   /// Adds a new layout
   Future<void> addLayout(Layout layout) {
     if (!layouts.contains(layout)) {

--- a/lib/providers/downloads_provider.dart
+++ b/lib/providers/downloads_provider.dart
@@ -28,6 +28,13 @@ import 'package:bluecherry_client/utils/storage.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:path/path.dart' as path;
+import 'package:path_provider/path_provider.dart';
+
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:path_provider_windows/path_provider_windows.dart'
+    hide WindowsKnownFolder;
+// ignore: implementation_imports
+import 'package:path_provider_windows/src/folders.dart' show WindowsKnownFolder;
 
 class DownloadedEvent {
   final Event event;
@@ -94,6 +101,24 @@ class DownloadsManager extends ChangeNotifier {
     instance = DownloadsManager._();
     await instance.initialize();
     return instance;
+  }
+
+  static Future<Directory> get kDefaultDownloadsDirectory async {
+    Directory? dir;
+    if (PathProviderPlatform.instance is PathProviderWindows) {
+      final instance = PathProviderPlatform.instance as PathProviderWindows;
+      final videosPath =
+          // ignore: unnecessary_cast
+          await instance.getPath(WindowsKnownFolder.Videos) as String;
+      dir = Directory(path.join(videosPath, 'Bluecherry Client', 'Downloads'));
+    }
+
+    if (dir == null) {
+      final docsDir = await getApplicationSupportDirectory();
+      dir = Directory(path.join(docsDir.path, 'downloads'));
+    }
+
+    return dir.create(recursive: true);
   }
 
   /// All the downloaded events

--- a/lib/providers/home_provider.dart
+++ b/lib/providers/home_provider.dart
@@ -118,29 +118,20 @@ class HomeProvider extends ChangeNotifier {
       final home = context.read<HomeProvider>();
       final tab = home.tab;
 
-      /// On device grid, use landscape
-      if ([UnityTab.deviceGrid].contains(tab)) {
-        setDefaultStatusBarStyle();
-        DeviceOrientations.instance.set([
-          DeviceOrientation.landscapeLeft,
-          DeviceOrientation.landscapeRight,
-        ]);
-      } else if ([UnityTab.directCameraScreen].contains(tab)) {
-        setDefaultStatusBarStyle();
-        DeviceOrientations.instance.set([
-          DeviceOrientation.portraitUp,
-          DeviceOrientation.portraitDown,
-        ]);
-      } else if ([UnityTab.addServer].contains(tab)) {
-        setDefaultStatusBarStyle(isLight: true);
-        DeviceOrientations.instance.set([
-          DeviceOrientation.portraitUp,
-          DeviceOrientation.portraitDown,
-        ]);
-      } else {
-        // Restore the values
-        setDefaultStatusBarStyle();
-        DeviceOrientations.instance.set(DeviceOrientation.values);
+      switch (tab) {
+        case UnityTab.deviceGrid:
+          setDefaultStatusBarStyle();
+          DeviceOrientations.instance.set([
+            DeviceOrientation.landscapeLeft,
+            DeviceOrientation.landscapeRight,
+          ]);
+          break;
+        default:
+          setDefaultStatusBarStyle();
+          // The empty list causes the application to defer to the operating system default.
+          // [SystemChrome.setPreferredOrientations]
+          DeviceOrientations.instance.set([]);
+          break;
       }
     }
   }

--- a/lib/providers/home_provider.dart
+++ b/lib/providers/home_provider.dart
@@ -66,21 +66,22 @@ class HomeProvider extends ChangeNotifier {
 
   static HomeProvider get instance => _instance;
 
-  int tab = ServersProvider.instance.serverAdded
-      ? UnityTab.deviceGrid.index
-      : UnityTab.addServer.index;
+  UnityTab tab = ServersProvider.instance.hasServers
+      ? UnityTab.deviceGrid
+      : UnityTab.addServer;
 
   List<UnityLoadingReason> loadReasons = [];
 
-  Future<void> setTab(int tab, BuildContext context) async {
-    if (tab.isNegative) return;
+  Future<void> setTab(UnityTab tab, BuildContext context) async {
+    if (tab == this.tab) return;
+
     this.tab = tab;
 
-    if (tab != UnityTab.downloads.index) {
+    if (tab != UnityTab.downloads) {
       initiallyExpandedDownloadEventId = null;
     }
 
-    if (tab != UnityTab.addServer.index) {
+    if (tab != UnityTab.addServer) {
       automaticallyGoToAddServersScreen = false;
     }
 
@@ -94,7 +95,7 @@ class HomeProvider extends ChangeNotifier {
   void toDownloads(int eventId, BuildContext context) {
     initiallyExpandedDownloadEventId = eventId;
 
-    setTab(UnityTab.downloads.index, context);
+    setTab(UnityTab.downloads, context);
   }
 
   static Future<void> setDefaultStatusBarStyle({bool? isLight}) async {
@@ -118,19 +119,19 @@ class HomeProvider extends ChangeNotifier {
       final tab = home.tab;
 
       /// On device grid, use landscape
-      if ([UnityTab.deviceGrid.index].contains(tab)) {
+      if ([UnityTab.deviceGrid].contains(tab)) {
         setDefaultStatusBarStyle();
         DeviceOrientations.instance.set([
           DeviceOrientation.landscapeLeft,
           DeviceOrientation.landscapeRight,
         ]);
-      } else if ([UnityTab.directCameraScreen.index].contains(tab)) {
+      } else if ([UnityTab.directCameraScreen].contains(tab)) {
         setDefaultStatusBarStyle();
         DeviceOrientations.instance.set([
           DeviceOrientation.portraitUp,
           DeviceOrientation.portraitDown,
         ]);
-      } else if ([UnityTab.addServer.index].contains(tab)) {
+      } else if ([UnityTab.addServer].contains(tab)) {
         setDefaultStatusBarStyle(isLight: true);
         DeviceOrientations.instance.set([
           DeviceOrientation.portraitUp,

--- a/lib/providers/mobile_view_provider.dart
+++ b/lib/providers/mobile_view_provider.dart
@@ -196,12 +196,8 @@ class MobileViewProvider extends ChangeNotifier {
   /// e.g. in response to a network error etc.
   Future<void> reload(int tab, int index) async {
     final device = devices[tab]![index]!;
-    await UnityPlayers.players[device]?.reset();
-    await UnityPlayers.players[device]?.setDataSource(device.streamURL);
-    await UnityPlayers.players[device]?.setVolume(0.0);
-    await UnityPlayers.players[device]?.setSpeed(1.0);
+    await UnityPlayers.reloadDevice(device);
     notifyListeners();
-    return _save(notifyListeners: false);
   }
 
   /// Saves current layout/order of [Device]s to cache using `package:hive`.

--- a/lib/providers/server_provider.dart
+++ b/lib/providers/server_provider.dart
@@ -47,7 +47,8 @@ class ServersProvider extends ChangeNotifier {
     return instance;
   }
 
-  bool get serverAdded => servers.isNotEmpty;
+  /// Whether any server is added.
+  bool get hasServers => servers.isNotEmpty;
 
   List<Server> servers = <Server>[];
 

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -19,14 +19,13 @@
 
 import 'dart:io';
 
+import 'package:bluecherry_client/providers/downloads_provider.dart';
 import 'package:bluecherry_client/providers/home_provider.dart';
 import 'package:bluecherry_client/utils/constants.dart';
 import 'package:bluecherry_client/utils/storage.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:intl/intl.dart';
-import 'package:path/path.dart' as path;
-import 'package:path_provider/path_provider.dart';
 import 'package:system_date_time_format/system_date_time_format.dart';
 import 'package:unity_video_player/unity_video_player.dart';
 
@@ -44,10 +43,8 @@ class SettingsProvider extends ChangeNotifier {
   static const kDefaultCameraViewFit = UnityVideoFit.contain;
   static const kDefaultLayoutCyclingEnabled = false;
   static const kDefaultLayoutCyclingTogglePeriod = Duration(seconds: 30);
-  static Future<Directory> kDefaultDownloadsDirectory() async {
-    final docsDir = await getApplicationSupportDirectory();
-    return Directory(path.join(docsDir.path, 'downloads')).create();
-  }
+  static Future<Directory> get kDefaultDownloadsDirectory =>
+      DownloadsManager.kDefaultDownloadsDirectory;
 
   // Getters.
   ThemeMode get themeMode => _themeMode;
@@ -203,7 +200,7 @@ class SettingsProvider extends ChangeNotifier {
     if (data.containsKey(kHiveDownloadsDirectorySetting)) {
       _downloadsDirectory = data[kHiveDownloadsDirectorySetting];
     } else {
-      _downloadsDirectory = (await kDefaultDownloadsDirectory()).path;
+      _downloadsDirectory = (await kDefaultDownloadsDirectory).path;
     }
 
     if (data.containsKey(kHiveLayoutCycling)) {

--- a/lib/utils/extensions.dart
+++ b/lib/utils/extensions.dart
@@ -80,11 +80,11 @@ extension DurationExtension on Duration {
 extension CameraViewFitExtension on UnityVideoFit {
   String locale(BuildContext context) {
     final loc = AppLocalizations.of(context);
-    return {
-      UnityVideoFit.contain: loc.contain,
-      UnityVideoFit.cover: loc.cover,
-      UnityVideoFit.fill: loc.fill,
-    }[this]!;
+    return switch (this) {
+      UnityVideoFit.contain => loc.contain,
+      UnityVideoFit.fill => loc.fill,
+      UnityVideoFit.cover => loc.cover,
+    };
   }
 
   IconData get icon {
@@ -99,14 +99,13 @@ extension CameraViewFitExtension on UnityVideoFit {
 extension UnityVideoQualityExtension on UnityVideoQuality {
   String locale(BuildContext context) {
     final loc = AppLocalizations.of(context);
-    return {
-          UnityVideoQuality.p1080: loc.p1080,
-          UnityVideoQuality.p720: loc.p720,
-          UnityVideoQuality.p480: loc.p480,
-          UnityVideoQuality.p360: loc.p360,
-          UnityVideoQuality.p240: loc.p240,
-        }[this] ??
-        name;
+    return switch (this) {
+      UnityVideoQuality.p1080 => loc.p1080,
+      UnityVideoQuality.p720 => loc.p720,
+      UnityVideoQuality.p480 => loc.p480,
+      UnityVideoQuality.p360 => loc.p360,
+      UnityVideoQuality.p240 => loc.p240,
+    };
   }
 }
 

--- a/lib/utils/extensions.dart
+++ b/lib/utils/extensions.dart
@@ -131,10 +131,21 @@ extension ServerExtension on List<Server> {
 }
 
 extension DateTimeExtension on DateTime {
-  bool isInBetween(DateTime first, DateTime second) {
-    return (isAfter(first) && isBefore(second)) ||
-        isAtSameMomentAs(first) ||
-        isAtSameMomentAs(second);
+  /// Returns true if this date is between [first] and [second]
+  ///
+  /// If [allowSameMoment] is true, then the date can be equal to [first] or [second].
+  bool isInBetween(
+    DateTime first,
+    DateTime second, {
+    bool allowSameMoment = false,
+  }) {
+    final isBetween = toLocal().isAfter(first.toLocal()) &&
+        toLocal().isBefore(second.toLocal());
+
+    if (allowSameMoment) return isBetween;
+    return isBetween ||
+        toLocal().isAtSameMomentAs(first.toLocal()) ||
+        toLocal().isAtSameMomentAs(second.toLocal());
   }
 }
 

--- a/lib/utils/methods.dart
+++ b/lib/utils/methods.dart
@@ -109,6 +109,7 @@ bool get isMobile {
   return [
     TargetPlatform.android,
     TargetPlatform.iOS,
+    TargetPlatform.fuchsia,
   ].contains(defaultTargetPlatform);
 }
 

--- a/lib/utils/theme.dart
+++ b/lib/utils/theme.dart
@@ -250,7 +250,6 @@ ThemeData createTheme({
       height: isMobile ? 32.0 : null,
       verticalOffset: isDesktop ? 28.0 : null,
       preferBelow: isDesktop ? true : null,
-      waitDuration: const Duration(seconds: 1),
     ),
     fontFamily: defaultTargetPlatform == TargetPlatform.linux ? 'Inter' : null,
     expansionTileTheme: const ExpansionTileThemeData(

--- a/lib/utils/tree_view/tree_view.dart
+++ b/lib/utils/tree_view/tree_view.dart
@@ -11,16 +11,16 @@ Widget buildCheckbox({
   required bool? value,
   required ValueChanged<bool?> onChanged,
   required bool isError,
+  required String text,
+  required double gapCheckboxText,
+  String? secondaryText,
   double checkboxScale = 0.8,
 }) {
-  return Transform.scale(
+  final checkbox = Transform.scale(
     scale: checkboxScale,
     child: Checkbox(
       materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-      visualDensity: const VisualDensity(
-        horizontal: -4,
-        vertical: -4,
-      ),
+      visualDensity: const VisualDensity(horizontal: -4, vertical: -4),
       splashRadius: 0.0,
       tristate: true,
       value: value,
@@ -28,6 +28,40 @@ Widget buildCheckbox({
       onChanged: onChanged,
     ),
   );
+
+  return Builder(builder: (context) {
+    final theme = Theme.of(context);
+    return Row(children: [
+      checkbox,
+      Expanded(
+        child: MouseRegion(
+          cursor: SystemMouseCursors.click,
+          child: GestureDetector(
+            onTap: () {
+              onChanged(value == null ? true : !value);
+            },
+            child: Row(children: [
+              SizedBox(width: gapCheckboxText),
+              Flexible(
+                child: Text(
+                  text,
+                  overflow: TextOverflow.ellipsis,
+                  maxLines: 1,
+                  softWrap: false,
+                ),
+              ),
+              if (secondaryText != null)
+                Text(
+                  secondaryText,
+                  style: theme.textTheme.labelSmall,
+                ),
+              const SizedBox(width: 10.0),
+            ]),
+          ),
+        ),
+      )
+    ]);
+  });
 }
 
 /// Tree view with collapsible and expandable nodes.

--- a/lib/utils/video_player.dart
+++ b/lib/utils/video_player.dart
@@ -21,8 +21,10 @@ import 'package:bluecherry_client/models/device.dart';
 import 'package:flutter/foundation.dart';
 import 'package:unity_video_player/unity_video_player.dart';
 
-class UnityPlayers {
-  const UnityPlayers._();
+class UnityPlayers with ChangeNotifier {
+  UnityPlayers._();
+
+  static final instance = UnityPlayers._();
 
   /// Instances of video players corresponding to a particular [Device].
   ///
@@ -45,9 +47,24 @@ class UnityPlayers {
     return controller;
   }
 
-  static void releaseDevice(Device device) {
-    players[device]?.release();
-    players[device]?.dispose();
+  /// Release the video player for the given [Device].
+  static Future<void> releaseDevice(Device device) async {
+    await players[device]?.release();
+    await players[device]?.dispose();
     players.remove(device);
+  }
+
+  /// Reload the video player for the given [Device].
+  static Future<void> reloadDevice(Device device) async {
+    await releaseDevice(device);
+    players[device] = forDevice(device);
+    instance.notifyListeners();
+  }
+
+  /// Reload all video players.
+  static void reloadAll() {
+    for (final device in players.keys) {
+      reloadDevice(device);
+    }
   }
 }

--- a/lib/widgets/add_server_wizard.dart
+++ b/lib/widgets/add_server_wizard.dart
@@ -176,7 +176,7 @@ class _AddServerWizardState extends State<AddServerWizard> {
                     ),
                     const SizedBox(height: 16.0),
                     Material(
-                      color: theme.colorScheme.secondary,
+                      // color: theme.colorScheme.primaryContainer,
                       child: InkWell(
                         onTap: () {
                           controller.nextPage(
@@ -190,8 +190,8 @@ class _AddServerWizardState extends State<AddServerWizard> {
                           height: 56.0,
                           child: Text(
                             loc.letsGo.toUpperCase(),
-                            style: const TextStyle(
-                              color: Colors.white,
+                            style: TextStyle(
+                              color: theme.colorScheme.onPrimaryContainer,
                               fontSize: 16.0,
                               fontWeight: FontWeight.w600,
                             ),
@@ -293,7 +293,6 @@ class _ConfigureDVRServerScreenState extends State<ConfigureDVRServerScreen> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final loc = AppLocalizations.of(context);
-    final buttonOpacity = disableFinishButton ? 0.5 : 1.0;
 
     return WillPopScope(
       onWillPop: () async {
@@ -362,6 +361,7 @@ class _ConfigureDVRServerScreenState extends State<ConfigureDVRServerScreen> {
                   Expanded(
                     flex: 5,
                     child: TextFormField(
+                      enabled: !disableFinishButton,
                       validator: (value) {
                         if (value?.isEmpty ?? true) {
                           return loc.errorTextField(
@@ -386,6 +386,7 @@ class _ConfigureDVRServerScreenState extends State<ConfigureDVRServerScreen> {
                   Expanded(
                     flex: 2,
                     child: TextFormField(
+                      enabled: !disableFinishButton,
                       validator: (value) {
                         if (value?.isEmpty ?? true) {
                           return loc.errorTextField(
@@ -407,6 +408,7 @@ class _ConfigureDVRServerScreenState extends State<ConfigureDVRServerScreen> {
                 ]),
                 const SizedBox(height: 16.0),
                 TextFormField(
+                  enabled: !disableFinishButton,
                   validator: (value) {
                     if (value?.isEmpty ?? true) {
                       return loc.errorTextField(
@@ -429,6 +431,7 @@ class _ConfigureDVRServerScreenState extends State<ConfigureDVRServerScreen> {
                 Row(children: [
                   Expanded(
                     child: TextFormField(
+                      enabled: !disableFinishButton,
                       validator: (value) {
                         if (value?.isEmpty ?? true) {
                           return loc.errorTextField(
@@ -455,7 +458,6 @@ class _ConfigureDVRServerScreenState extends State<ConfigureDVRServerScreen> {
                               textEditingControllers[3].text = kDefaultUsername;
                               textEditingControllers[4].text = kDefaultPassword;
                             },
-                      textColor: theme.colorScheme.secondary,
                       child: Text(loc.useDefault.toUpperCase()),
                     ),
                   ),
@@ -464,6 +466,7 @@ class _ConfigureDVRServerScreenState extends State<ConfigureDVRServerScreen> {
                 Row(crossAxisAlignment: CrossAxisAlignment.start, children: [
                   Expanded(
                     child: TextFormField(
+                      enabled: !disableFinishButton,
                       validator: (value) {
                         if (value?.isEmpty ?? true) {
                           return loc.errorTextField(
@@ -542,9 +545,6 @@ class _ConfigureDVRServerScreenState extends State<ConfigureDVRServerScreen> {
                               curve: Curves.easeInOut,
                             );
                           },
-                    textColor: theme.colorScheme.secondary.withOpacity(
-                      buttonOpacity,
-                    ),
                     child: Padding(
                       padding: const EdgeInsetsDirectional.all(8.0),
                       child: Text(loc.skip.toUpperCase()),
@@ -553,9 +553,6 @@ class _ConfigureDVRServerScreenState extends State<ConfigureDVRServerScreen> {
                   MaterialButton(
                     onPressed:
                         disableFinishButton ? null : () => finish(context),
-                    textColor: theme.colorScheme.secondary.withOpacity(
-                      buttonOpacity,
-                    ),
                     child: Padding(
                       padding: const EdgeInsetsDirectional.all(8.0),
                       child: Text(loc.finish.toUpperCase()),
@@ -607,20 +604,27 @@ class _ConfigureDVRServerScreenState extends State<ConfigureDVRServerScreen> {
               final loc = AppLocalizations.of(context);
 
               return AlertDialog(
-                title: Text(loc.error),
+                title: Text(loc.serverNotAddedError(server.name)),
                 content: Text(
-                  loc.serverNotAddedError(server.name),
+                  loc.serverNotAddedErrorDescription,
                   style: theme.textTheme.headlineMedium,
                 ),
                 actions: [
-                  MaterialButton(
-                    onPressed: Navigator.of(context).maybePop,
-                    textColor: theme.colorScheme.secondary,
+                  TextButton(
+                    onPressed: () {
+                      Navigator.of(context).maybePop();
+                      if (this.context.mounted) finish(this.context);
+                    },
                     child: Padding(
                       padding: const EdgeInsetsDirectional.all(8.0),
-                      child: Text(
-                        loc.ok,
-                      ),
+                      child: Text(loc.retry.toUpperCase()),
+                    ),
+                  ),
+                  MaterialButton(
+                    onPressed: Navigator.of(context).maybePop,
+                    child: Padding(
+                      padding: const EdgeInsetsDirectional.all(8.0),
+                      child: Text(loc.ok),
                     ),
                   ),
                 ],
@@ -813,7 +817,6 @@ class _LetsGoScreenState extends State<LetsGoScreen> {
           onPressed: () {
             widget.onFinish.call();
           },
-          backgroundColor: theme.colorScheme.secondary,
           label: Text(loc.finish.toUpperCase()),
           icon: const Icon(Icons.check),
         ),

--- a/lib/widgets/desktop_buttons.dart
+++ b/lib/widgets/desktop_buttons.dart
@@ -178,13 +178,12 @@ class _WindowButtonsState extends State<WindowButtons> with WindowListener {
                           }
                         }
 
-                        final names = navData.map((d) => d.text);
-
-                        if (tab >= names.length) {
+                        // If it is in another screen, show the title or fallback to "Bluecherry"
+                        if (tab.index >= UnityTab.values.length) {
                           return widget.title ?? 'Bluecherry';
                         }
 
-                        return names.elementAt(tab);
+                        return navData.firstWhere((d) => d.tab == tab).text;
                       }(),
                       style: TextStyle(
                         color: theme.brightness == Brightness.light
@@ -202,8 +201,8 @@ class _WindowButtonsState extends State<WindowButtons> with WindowListener {
                     padding: EdgeInsets.symmetric(horizontal: 8.0),
                     child: UnityLoadingIndicator(),
                   )
-                else if (home.tab == UnityTab.eventsScreen.index ||
-                    home.tab == UnityTab.eventsPlayback.index && !canPop)
+                else if (home.tab == UnityTab.eventsScreen ||
+                    home.tab == UnityTab.eventsPlayback && !canPop)
                   IconButton(
                     onPressed: () {
                       eventsScreenKey.currentState?.fetch();
@@ -229,9 +228,7 @@ class _WindowButtonsState extends State<WindowButtons> with WindowListener {
                 child:
                     Row(mainAxisAlignment: MainAxisAlignment.center, children: [
                   ...navData.map((data) {
-                    final index = navData.indexOf(data);
-                    final isSelected = tab == index;
-
+                    final isSelected = tab == data.tab;
                     final icon = isSelected ? data.selectedIcon : data.icon;
                     final text = data.text;
 
@@ -249,7 +246,7 @@ class _WindowButtonsState extends State<WindowButtons> with WindowListener {
                       ),
                       iconSize: 22.0,
                       tooltip: text,
-                      onPressed: () => home.setTab(index, context),
+                      onPressed: () => home.setTab(data.tab, context),
                     );
                   }),
                 ]),

--- a/lib/widgets/device_grid/desktop/desktop_device_grid.dart
+++ b/lib/widgets/device_grid/desktop/desktop_device_grid.dart
@@ -280,7 +280,7 @@ class LayoutView extends StatelessWidget {
               topEnd: isReversed ? const Radius.circular(8.0) : Radius.zero,
             ),
           ),
-          child: Center(child: child),
+          child: SafeArea(child: Center(child: child)),
         );
       },
     );

--- a/lib/widgets/device_grid/desktop/desktop_device_grid.dart
+++ b/lib/widgets/device_grid/desktop/desktop_device_grid.dart
@@ -301,6 +301,9 @@ class _DesktopDeviceTileState extends State<DesktopDeviceTile> {
 
   @override
   Widget build(BuildContext context) {
+    // watch for changes in the players list. usually happens when reloading
+    // or releasing a device
+    context.watch<UnityPlayers>();
     final videoPlayer = UnityPlayers.players[widget.device];
 
     if (videoPlayer == null) {
@@ -569,7 +572,10 @@ class _DesktopTileViewportState extends State<DesktopTileViewport> {
                       tooltip: loc.reloadCamera,
                       color: Colors.white,
                       iconSize: 18.0,
-                      onPressed: () => view.reload(widget.device),
+                      onPressed: () async {
+                        await UnityPlayers.reloadDevice(widget.device);
+                        setState(() {});
+                      },
                     ),
                     CameraViewFitButton(
                       fit: context

--- a/lib/widgets/device_grid/desktop/layout_manager.dart
+++ b/lib/widgets/device_grid/desktop/layout_manager.dart
@@ -156,7 +156,7 @@ class _LayoutManagerState extends State<LayoutManager> {
   }
 }
 
-class LayoutTile extends StatelessWidget {
+class LayoutTile extends StatefulWidget {
   const LayoutTile({
     super.key,
     required this.layout,
@@ -169,40 +169,60 @@ class LayoutTile extends StatelessWidget {
   final int reorderableIndex;
 
   @override
+  State<LayoutTile> createState() => _LayoutTileState();
+}
+
+class _LayoutTileState extends State<LayoutTile> {
+  PointerDeviceKind? longPressKind;
+
+  @override
   Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context);
     final view = context.watch<DesktopViewProvider>();
 
     return ReorderableDragStartListener(
-      index: reorderableIndex,
-      enabled: selected,
+      index: widget.reorderableIndex,
+      enabled: widget.selected,
       child: HoverButton(
+        hitTestBehavior: HitTestBehavior.translucent,
         onSecondaryTap: () => _displayOptions(context),
-        onLongPressDown: (d) {
-          if (d.kind == PointerDeviceKind.touch) _displayOptions(context);
+        onLongPressDown: (d) => longPressKind = d.kind,
+        onLongPressStart: (d) {
+          switch (longPressKind) {
+            case PointerDeviceKind.touch:
+            case PointerDeviceKind.stylus:
+            case PointerDeviceKind.invertedStylus:
+              _displayOptions(context);
+              break;
+            default:
+              break;
+          }
         },
+        onLongPressEnd: (d) => longPressKind = null,
+        onLongPressCancel: () => longPressKind = null,
+        onLongPressUp: () => longPressKind = null,
         builder: (context, states) => ListTile(
           dense: true,
           visualDensity: VisualDensity.compact,
-          selected: selected,
+          selected: widget.selected,
           leading: AnimatedSwitcher(
             duration: const Duration(milliseconds: 150),
             child: ReorderableDragStartListener(
-              index: reorderableIndex,
-              enabled: !selected,
+              index: widget.reorderableIndex,
+              enabled: !widget.selected,
               child: Icon(
-                selected
-                    ? selectedIconForLayout(layout.type)
-                    : iconForLayout(layout.type),
-                key: ValueKey(layout.type),
+                widget.selected
+                    ? selectedIconForLayout(widget.layout.type)
+                    : iconForLayout(widget.layout.type),
+                key: ValueKey(widget.layout.type),
                 size: 20.0,
               ),
             ),
           ),
           minLeadingWidth: 24.0,
-          title: Text(layout.name, maxLines: 1),
+          title: Text(widget.layout.name, maxLines: 1),
           subtitle: Text(
-            loc.nDevices(layout.devices.length),
+            loc.nDevices(widget.layout.devices.length),
             maxLines: 1,
           ),
           trailing: states.isHovering
@@ -216,8 +236,9 @@ class LayoutTile extends StatelessWidget {
                   ),
                 )
               : null,
-          onTap: !selected
-              ? () => view.updateCurrentLayout(view.layouts.indexOf(layout))
+          onTap: !widget.selected
+              ? () =>
+                  view.updateCurrentLayout(view.layouts.indexOf(widget.layout))
               : null,
         ),
       ),
@@ -257,7 +278,7 @@ class LayoutTile extends StatelessWidget {
           label: Padding(
             padding: padding.add(const EdgeInsets.symmetric(vertical: 6.0)),
             child: Text(
-              layout.name,
+              widget.layout.name,
               maxLines: 1,
               style: theme.textTheme.labelSmall,
             ),
@@ -269,18 +290,18 @@ class LayoutTile extends StatelessWidget {
           onTap: () {
             showDialog(
               context: context,
-              builder: (context) => EditLayoutDialog(layout: layout),
+              builder: (context) => EditLayoutDialog(layout: widget.layout),
             );
           },
         ),
         if (isDesktopPlatform)
           PopupMenuItem(
-            onTap: layout.openInANewWindow,
+            onTap: widget.layout.openInANewWindow,
             child: Text(loc.openInANewWindow),
           ),
         PopupMenuItem(
           onTap: () {
-            layout.export(dialogTitle: loc.exportLayout);
+            widget.layout.export(dialogTitle: loc.exportLayout);
           },
           child: Text(loc.exportLayout),
         ),

--- a/lib/widgets/device_grid/desktop/layout_manager.dart
+++ b/lib/widgets/device_grid/desktop/layout_manager.dart
@@ -23,6 +23,7 @@ import 'dart:io';
 import 'package:bluecherry_client/models/layout.dart';
 import 'package:bluecherry_client/providers/desktop_view_provider.dart';
 import 'package:bluecherry_client/providers/settings_provider.dart';
+import 'package:bluecherry_client/utils/methods.dart';
 import 'package:bluecherry_client/utils/window.dart';
 import 'package:bluecherry_client/widgets/hover_button.dart';
 import 'package:bluecherry_client/widgets/misc.dart';
@@ -86,49 +87,51 @@ class _LayoutManagerState extends State<LayoutManager> {
       child: Column(children: [
         Material(
           color: theme.appBarTheme.backgroundColor,
-          child: Padding(
-            padding: const EdgeInsetsDirectional.only(
-              top: 2.0,
-              bottom: 2.0,
-              end: 12.0,
+          child: SafeArea(
+            child: Padding(
+              padding: const EdgeInsetsDirectional.only(
+                top: 2.0,
+                bottom: 2.0,
+                end: 12.0,
+              ),
+              child: Row(children: [
+                widget.collapseButton,
+                const SizedBox(width: 5.0),
+                Expanded(
+                  child: Text(
+                    loc.view,
+                    maxLines: 1,
+                  ),
+                ),
+                IconButton(
+                  icon: Icon(
+                    Icons.cyclone,
+                    size: 18.0,
+                    color: settings.layoutCyclingEnabled
+                        ? theme.colorScheme.primary
+                        : IconTheme.of(context).color,
+                  ),
+                  padding: EdgeInsets.zero,
+                  tooltip: loc.cycle,
+                  onPressed: settings.toggleCycling,
+                ),
+                IconButton(
+                  icon: Icon(
+                    Icons.add,
+                    size: 18.0,
+                    color: IconTheme.of(context).color,
+                  ),
+                  tooltip: loc.newLayout,
+                  padding: EdgeInsets.zero,
+                  onPressed: () {
+                    showDialog(
+                      context: context,
+                      builder: (context) => const NewLayoutDialog(),
+                    );
+                  },
+                ),
+              ]),
             ),
-            child: Row(children: [
-              widget.collapseButton,
-              const SizedBox(width: 5.0),
-              Expanded(
-                child: Text(
-                  loc.view,
-                  maxLines: 1,
-                ),
-              ),
-              IconButton(
-                icon: Icon(
-                  Icons.cyclone,
-                  size: 18.0,
-                  color: settings.layoutCyclingEnabled
-                      ? theme.colorScheme.primary
-                      : IconTheme.of(context).color,
-                ),
-                padding: EdgeInsets.zero,
-                tooltip: loc.cycle,
-                onPressed: settings.toggleCycling,
-              ),
-              IconButton(
-                icon: Icon(
-                  Icons.add,
-                  size: 18.0,
-                  color: IconTheme.of(context).color,
-                ),
-                tooltip: loc.newLayout,
-                padding: EdgeInsets.zero,
-                onPressed: () {
-                  showDialog(
-                    context: context,
-                    builder: (context) => const NewLayoutDialog(),
-                  );
-                },
-              ),
-            ]),
           ),
         ),
         Expanded(
@@ -270,10 +273,11 @@ class LayoutTile extends StatelessWidget {
             );
           },
         ),
-        PopupMenuItem(
-          onTap: layout.openInANewWindow,
-          child: Text(loc.openInANewWindow),
-        ),
+        if (isDesktopPlatform)
+          PopupMenuItem(
+            onTap: layout.openInANewWindow,
+            child: Text(loc.openInANewWindow),
+          ),
         PopupMenuItem(
           onTap: () {
             layout.export(dialogTitle: loc.exportLayout);

--- a/lib/widgets/device_grid/mobile/device_view.dart
+++ b/lib/widgets/device_grid/mobile/device_view.dart
@@ -233,8 +233,6 @@ class DeviceTile extends StatefulWidget {
 }
 
 class DeviceTileState extends State<DeviceTile> {
-  UnityVideoPlayer? get videoPlayer => UnityPlayers.players[widget.device];
-
   bool get hover =>
       context.read<MobileViewProvider>().hoverStates[widget.tab]
           ?[widget.index] ??
@@ -246,6 +244,8 @@ class DeviceTileState extends State<DeviceTile> {
 
   @override
   Widget build(BuildContext context) {
+    context.watch<UnityPlayers>();
+    final videoPlayer = UnityPlayers.players[widget.device];
     if (videoPlayer == null) return const SizedBox.shrink();
 
     final loc = AppLocalizations.of(context);
@@ -258,8 +258,6 @@ class DeviceTileState extends State<DeviceTile> {
       },
       // Fullscreen on double-tap.
       onDoubleTap: () async {
-        if (videoPlayer == null) return;
-
         await Navigator.of(context).pushNamed(
           '/fullscreen',
           arguments: {
@@ -270,7 +268,7 @@ class DeviceTileState extends State<DeviceTile> {
       },
       child: UnityVideoView(
         heroTag: widget.device.streamURL,
-        player: videoPlayer!,
+        player: videoPlayer,
         fit: settings.cameraViewFit,
         paneBuilder: (context, controller) {
           final video = UnityVideoView.of(context);
@@ -280,7 +278,7 @@ class DeviceTileState extends State<DeviceTile> {
             child: Stack(children: [
               if (error != null)
                 ErrorWarning(message: error)
-              else if (!controller.isSeekable || videoPlayer == null)
+              else if (!controller.isSeekable)
                 const Center(
                   child: CircularProgressIndicator.adaptive(
                     valueColor: AlwaysStoppedAnimation(Colors.white),
@@ -304,8 +302,6 @@ class DeviceTileState extends State<DeviceTile> {
                     child: IconButton(
                       splashRadius: 20.0,
                       onPressed: () async {
-                        if (videoPlayer == null) return;
-
                         await Navigator.of(context).pushNamed(
                           '/fullscreen',
                           arguments: {

--- a/lib/widgets/device_grid/mobile/device_view.dart
+++ b/lib/widgets/device_grid/mobile/device_view.dart
@@ -111,18 +111,18 @@ class _MobileDeviceViewState extends State<MobileDeviceView> {
                     buttonPos.dy + menuWidth,
                   );
 
-                  final value = await showMenu<int>(
+                  final value = await showMenu<IconData>(
                     context: context,
                     position: position,
                     constraints: const BoxConstraints(
                       maxWidth: menuWidth,
                       minWidth: menuWidth,
                     ),
-                    items: [
-                      loc.removeCamera,
-                      loc.replaceCamera,
-                      loc.reloadCamera,
-                    ].asMap().entries.map((e) {
+                    items: {
+                      Icons.close_outlined: loc.removeCamera,
+                      Icons.add_outlined: loc.replaceCamera,
+                      Icons.replay_outlined: loc.reloadCamera,
+                    }.entries.map((e) {
                       return PopupMenuItem(
                         value: e.key,
                         padding: EdgeInsets.zero,
@@ -130,11 +130,7 @@ class _MobileDeviceViewState extends State<MobileDeviceView> {
                           leading: CircleAvatar(
                             backgroundColor: Colors.transparent,
                             foregroundColor: theme.iconTheme.color,
-                            child: Icon(<int, IconData>{
-                              0: Icons.close_outlined,
-                              1: Icons.add_outlined,
-                              2: Icons.replay_outlined,
-                            }[e.key]!),
+                            child: Icon(e.key),
                           ),
                           title: Text(e.value),
                         ),
@@ -145,12 +141,12 @@ class _MobileDeviceViewState extends State<MobileDeviceView> {
                   if (value == null || !mounted) return;
 
                   switch (value) {
-                    case 0:
+                    case Icons.close_outlined:
                       view.remove(widget.tab, widget.index);
                       if (mounted) setState(() {});
 
                       break;
-                    case 1:
+                    case Icons.add_outlined:
                       if (mounted) {
                         final result = await showDeviceSelectorScreen(context);
                         if (result != null) {
@@ -159,7 +155,7 @@ class _MobileDeviceViewState extends State<MobileDeviceView> {
                         }
                       }
                       break;
-                    case 2:
+                    case Icons.replay_outlined:
                       view.reload(widget.tab, widget.index);
                       break;
                   }

--- a/lib/widgets/device_grid/mobile/mobile_device_grid.dart
+++ b/lib/widgets/device_grid/mobile/mobile_device_grid.dart
@@ -78,10 +78,9 @@ class _MobileDeviceGridState extends State<MobileDeviceGrid> {
       else
         Expanded(
           child: PageTransitionSwitcher(
-            child: {
-              for (var key in view.devices.keys)
-                key: _MobileDeviceGridChild(tab: key)
-            }[view.tab],
+            child: view.devices.keys
+                .map((key) => _MobileDeviceGridChild(tab: key))
+                .elementAt(view.tab),
             transitionBuilder: (child, primaryAnimation, secondaryAnimation) {
               return FadeThroughTransition(
                 animation: primaryAnimation,
@@ -209,18 +208,18 @@ class _MobileDeviceGridChild extends StatelessWidget {
           aspectRatio: 16 / 9,
           child: Center(
             child: StaticGrid(
-              crossAxisCount: <int, int>{
-                    9: 3,
-                    6: 3,
-                    4: 2,
-                    2: 2,
-                  }[tab] ??
-                  1,
-              childAspectRatio: <int, double>{
-                    2: width * 0.5 / height,
-                    4: width / height,
-                  }[tab] ??
-                  16 / 9,
+              crossAxisCount: switch (tab) {
+                9 => 3,
+                6 => 3,
+                4 => 2,
+                2 => 2,
+                _ => 1,
+              },
+              childAspectRatio: switch (tab) {
+                2 => width * 0.5 / height,
+                4 => width / height,
+                _ => 16 / 9,
+              },
               reorderable: view.current.any((device) => device != null),
               padding: EdgeInsets.zero,
               onReorder: (initial, end) => view.reorder(tab, initial, end),

--- a/lib/widgets/device_selector_screen.dart
+++ b/lib/widgets/device_selector_screen.dart
@@ -105,23 +105,25 @@ class DeviceSelectorScreen extends StatelessWidget {
             for (final server in servers.servers)
               MultiSliver(pushPinnedChildren: true, children: [
                 SliverPinnedHeader(
-                  child: SubHeader(
-                    server.name,
-                    subtext: server.online
-                        ? loc.nDevices(server.devices.length)
-                        : loc.offline,
-                    subtextStyle: TextStyle(
-                      color: !server.online ? theme.colorScheme.error : null,
+                  child: Material(
+                    child: SubHeader(
+                      server.name,
+                      subtext: server.online
+                          ? loc.nDevices(server.devices.length)
+                          : loc.offline,
+                      subtextStyle: TextStyle(
+                        color: !server.online ? theme.colorScheme.error : null,
+                      ),
+                      trailing: servers.isServerLoading(server)
+                          ? const SizedBox(
+                              height: 16.0,
+                              width: 16.0,
+                              child: CircularProgressIndicator.adaptive(
+                                strokeWidth: 1.5,
+                              ),
+                            )
+                          : null,
                     ),
-                    trailing: servers.isServerLoading(server)
-                        ? const SizedBox(
-                            height: 16.0,
-                            width: 16.0,
-                            child: CircularProgressIndicator.adaptive(
-                              strokeWidth: 1.5,
-                            ),
-                          )
-                        : null,
                   ),
                 ),
                 SliverList.builder(
@@ -175,6 +177,9 @@ class DeviceSelectorScreen extends StatelessWidget {
                         device.uri,
                         '${device.resolutionX}x${device.resolutionY}',
                       ].join(' • ')),
+                      trailing: device.hasPTZ
+                          ? const Icon(Icons.videogame_asset)
+                          : null,
                       onTap: () => Navigator.of(context).pop(device),
                     );
                   },

--- a/lib/widgets/direct_camera.dart
+++ b/lib/widgets/direct_camera.dart
@@ -22,7 +22,6 @@ import 'package:bluecherry_client/models/server.dart';
 import 'package:bluecherry_client/providers/server_provider.dart';
 import 'package:bluecherry_client/utils/constants.dart';
 import 'package:bluecherry_client/utils/extensions.dart';
-import 'package:bluecherry_client/utils/methods.dart';
 import 'package:bluecherry_client/utils/theme.dart';
 import 'package:bluecherry_client/utils/video_player.dart';
 import 'package:bluecherry_client/widgets/error_warning.dart';
@@ -45,20 +44,19 @@ class _DirectCameraScreenState extends State<DirectCameraScreen> {
     final loc = AppLocalizations.of(context);
 
     return Column(children: [
-      showIf(
-            Scaffold.hasDrawer(context),
-            child: AppBar(
-              leading: MaybeUnityDrawerButton(context),
-              title: Text(loc.directCamera),
-            ),
-          ) ??
-          const SizedBox.shrink(),
+      if (Scaffold.hasDrawer(context))
+        AppBar(
+          leading: MaybeUnityDrawerButton(context),
+          title: Text(loc.directCamera),
+        )
+      else
+        const SafeArea(child: SizedBox.shrink()),
       Expanded(
         child: () {
           if (serversProviders.servers.isEmpty) {
             return const NoServerWarning();
           } else {
-            return RefreshIndicator(
+            return RefreshIndicator.adaptive(
               onRefresh: serversProviders.refreshDevices,
               child: ListView.builder(
                 padding: MediaQuery.viewPaddingOf(context),

--- a/lib/widgets/direct_camera.dart
+++ b/lib/widgets/direct_camera.dart
@@ -30,14 +30,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 
-class DirectCameraScreen extends StatefulWidget {
+class DirectCameraScreen extends StatelessWidget {
   const DirectCameraScreen({super.key});
 
-  @override
-  State<DirectCameraScreen> createState() => _DirectCameraScreenState();
-}
-
-class _DirectCameraScreenState extends State<DirectCameraScreen> {
   @override
   Widget build(BuildContext context) {
     final serversProviders = context.watch<ServersProvider>();

--- a/lib/widgets/downloads_manager.dart
+++ b/lib/widgets/downloads_manager.dart
@@ -487,9 +487,7 @@ class NoDownloads extends StatelessWidget {
               color: Theme.of(context).colorScheme.primary,
             ),
             recognizer: TapGestureRecognizer()
-              ..onTap = () {
-                home.setTab(UnityTab.eventsScreen.index, context);
-              },
+              ..onTap = () => home.setTab(UnityTab.eventsScreen, context),
           ),
           textAlign: TextAlign.center,
         ),

--- a/lib/widgets/downloads_manager.dart
+++ b/lib/widgets/downloads_manager.dart
@@ -46,67 +46,60 @@ class DownloadsManagerScreen extends StatelessWidget {
     final downloads = context.watch<DownloadsManager>();
 
     return Column(children: [
-      showIf(
-            Scaffold.hasDrawer(context),
-            child: AppBar(
-              leading: MaybeUnityDrawerButton(context),
-              title: Text(loc.downloads),
-            ),
-          ) ??
-          const SizedBox.shrink(),
+      if (Scaffold.hasDrawer(context))
+        AppBar(
+          leading: MaybeUnityDrawerButton(context),
+          title: Text(loc.downloads),
+        )
+      else
+        const SafeArea(child: SizedBox.shrink()),
       Expanded(
         child: LayoutBuilder(builder: (context, consts) {
-          if (downloads.isEmpty) {
-            return const NoDownloads();
-          }
+          if (downloads.isEmpty) return const NoDownloads();
 
           final size = consts.biggest;
-          return CustomScrollView(
-            slivers: [
-              SliverPadding(
-                padding: const EdgeInsetsDirectional.only(
-                  top: _kDownloadsManagerPadding / 2,
-                  bottom: _kDownloadsManagerPadding / 2,
-                ),
-                sliver: SliverList.builder(
-                  itemCount: downloads.downloading.length,
-                  itemBuilder: (context, index) {
-                    final entry =
-                        downloads.downloading.entries.elementAt(index);
-                    final event = entry.key;
-                    final progress = entry.value;
-
-                    return DownloadTile(
-                      key: ValueKey(event.id),
-                      event: event,
-                      upcomingEvents: downloads.downloadedEvents
-                          .map((e) => e.event)
-                          .toList(),
-                      size: size,
-                      progress: progress,
-                      initiallyExpanded: initiallyExpandedEventId == event.id,
-                    );
-                  },
-                ),
+          return CustomScrollView(slivers: [
+            SliverPadding(
+              padding: const EdgeInsetsDirectional.only(
+                top: _kDownloadsManagerPadding / 2,
+                bottom: _kDownloadsManagerPadding / 2,
               ),
-              SliverList.builder(
-                itemCount: downloads.downloadedEvents.length,
+              sliver: SliverList.builder(
+                itemCount: downloads.downloading.length,
                 itemBuilder: (context, index) {
-                  final de = downloads.downloadedEvents[index];
+                  final entry = downloads.downloading.entries.elementAt(index);
+                  final event = entry.key;
+                  final progress = entry.value;
 
                   return DownloadTile(
-                    key: ValueKey(de.event.id),
-                    event: de.event,
+                    key: ValueKey(event.id),
+                    event: event,
                     upcomingEvents:
                         downloads.downloadedEvents.map((e) => e.event).toList(),
                     size: size,
-                    downloadPath: de.downloadPath,
-                    initiallyExpanded: initiallyExpandedEventId == de.event.id,
+                    progress: progress,
+                    initiallyExpanded: initiallyExpandedEventId == event.id,
                   );
                 },
               ),
-            ],
-          );
+            ),
+            SliverList.builder(
+              itemCount: downloads.downloadedEvents.length,
+              itemBuilder: (context, index) {
+                final de = downloads.downloadedEvents[index];
+
+                return DownloadTile(
+                  key: ValueKey(de.event.id),
+                  event: de.event,
+                  upcomingEvents:
+                      downloads.downloadedEvents.map((e) => e.event).toList(),
+                  size: size,
+                  downloadPath: de.downloadPath,
+                  initiallyExpanded: initiallyExpandedEventId == de.event.id,
+                );
+              },
+            ),
+          ]);
         }),
       ),
     ]);

--- a/lib/widgets/events/event_player_desktop.dart
+++ b/lib/widgets/events/event_player_desktop.dart
@@ -219,9 +219,8 @@ class _EventPlayerDesktopState extends State<EventPlayerDesktop> {
                                 snapshot.data ?? videoController.currentPos;
                             return Row(children: [
                               Text(
-                                DateFormat.Hms().format(
-                                  currentEvent.published.add(pos).toLocal(),
-                                ),
+                                DateFormat.Hms()
+                                    .format(currentEvent.published.add(pos)),
                               ),
                               padd,
                               Expanded(
@@ -271,7 +270,7 @@ class _EventPlayerDesktopState extends State<EventPlayerDesktop> {
                       padd,
                       Text(
                         DateFormat.Hms().format(
-                          currentEvent.published.add(duration).toLocal(),
+                          currentEvent.published.add(duration),
                         ),
                       ),
                       padd,

--- a/lib/widgets/events/events_screen.dart
+++ b/lib/widgets/events/events_screen.dart
@@ -322,7 +322,6 @@ class _EventsScreenState extends State<EventsScreen> {
     double gapCheckboxText = 0.0,
     required void Function(VoidCallback fn) setState,
   }) {
-    final theme = Theme.of(context);
     final servers = context.watch<ServersProvider>();
 
     return TreeView(
@@ -335,43 +334,30 @@ class _EventsScreenState extends State<EventsScreen> {
         final serverEvents = events[server];
 
         return TreeNode(
-          content: Row(children: [
-            buildCheckbox(
-              value: !allowedServers.contains(server) || isOffline
-                  ? false
-                  : isTriState
-                      ? null
-                      : true,
-              isError: isOffline,
-              onChanged: (v) {
-                setState(() {
-                  if (isTriState) {
-                    disabledDevices.removeWhere((d) =>
-                        server.devices.any((device) => device.rtspURL == d));
-                  } else if (v == null || !v) {
-                    allowedServers.remove(server);
-                  } else {
-                    allowedServers.add(server);
-                  }
-                });
-              },
-              checkboxScale: checkboxScale,
-            ),
-            SizedBox(width: gapCheckboxText),
-            Expanded(
-              child: Text(
-                server.name,
-                overflow: TextOverflow.ellipsis,
-                maxLines: 1,
-                softWrap: false,
-              ),
-            ),
-            Text(
-              '${server.devices.length}',
-              style: theme.textTheme.labelSmall,
-            ),
-            const SizedBox(width: 10.0),
-          ]),
+          content: buildCheckbox(
+            value: !allowedServers.contains(server) || isOffline
+                ? false
+                : isTriState
+                    ? null
+                    : true,
+            isError: isOffline,
+            onChanged: (v) {
+              setState(() {
+                if (isTriState) {
+                  disabledDevices.removeWhere((d) =>
+                      server.devices.any((device) => device.rtspURL == d));
+                } else if (v == null || !v) {
+                  allowedServers.remove(server);
+                } else {
+                  allowedServers.add(server);
+                }
+              });
+            },
+            checkboxScale: checkboxScale,
+            text: server.name,
+            secondaryText: '${server.devices.length}',
+            gapCheckboxText: gapCheckboxText,
+          ),
           children: () {
             if (isOffline) {
               return <TreeNode>[];
@@ -383,43 +369,30 @@ class _EventsScreenState extends State<EventsScreen> {
                 final eventsForDevice =
                     serverEvents?.where((event) => event.deviceID == device.id);
                 return TreeNode(
-                  content: Row(children: [
-                    IgnorePointer(
-                      ignoring: !device.status,
-                      child: buildCheckbox(
-                        value: device.status ? enabled : false,
-                        isError: !device.status,
-                        onChanged: (v) {
-                          if (!device.status) return;
+                  content: IgnorePointer(
+                    ignoring: !device.status,
+                    child: buildCheckbox(
+                      value: device.status ? enabled : false,
+                      isError: !device.status,
+                      onChanged: (v) {
+                        if (!device.status) return;
 
-                          setState(() {
-                            if (enabled) {
-                              disabledDevices.add(device.rtspURL);
-                            } else {
-                              disabledDevices.remove(device.rtspURL);
-                            }
-                          });
-                        },
-                        checkboxScale: checkboxScale,
-                      ),
+                        setState(() {
+                          if (enabled) {
+                            disabledDevices.add(device.rtspURL);
+                          } else {
+                            disabledDevices.remove(device.rtspURL);
+                          }
+                        });
+                      },
+                      checkboxScale: checkboxScale,
+                      text: device.name,
+                      secondaryText: eventsForDevice != null
+                          ? ' (${eventsForDevice.length})'
+                          : null,
+                      gapCheckboxText: gapCheckboxText,
                     ),
-                    SizedBox(width: gapCheckboxText),
-                    Flexible(
-                      child: Text(
-                        device.name,
-                        overflow: TextOverflow.ellipsis,
-                        maxLines: 1,
-                        softWrap: false,
-                      ),
-                    ),
-                    if (eventsForDevice != null) ...[
-                      Text(
-                        ' (${eventsForDevice.length})',
-                        style: theme.textTheme.labelSmall,
-                      ),
-                      const SizedBox(width: 10.0),
-                    ],
-                  ]),
+                  ),
                 );
               }).toList();
             }

--- a/lib/widgets/events/events_screen.dart
+++ b/lib/widgets/events/events_screen.dart
@@ -433,8 +433,8 @@ class _EventsScreenState extends State<EventsScreen> {
     return showModalBottomSheet(
       context: context,
       isScrollControlled: true,
+      showDragHandle: true,
       builder: (context) {
-        final theme = Theme.of(context);
         final loc = AppLocalizations.of(context);
 
         return DraggableScrollableSheet(
@@ -451,20 +451,6 @@ class _EventsScreenState extends State<EventsScreen> {
               }
 
               return ListView(controller: controller, children: [
-                Center(
-                  child: Container(
-                    width: 50,
-                    height: 6.0,
-                    decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(100),
-                      color: theme.dividerColor,
-                    ),
-                    margin: const EdgeInsets.symmetric(
-                      horizontal: 10.0,
-                      vertical: 12.0,
-                    ),
-                  ),
-                ),
                 const SubHeader('Time filter'),
                 DropdownButton<EventsTimeFilter>(
                   isExpanded: true,

--- a/lib/widgets/events/events_screen.dart
+++ b/lib/widgets/events/events_screen.dart
@@ -247,64 +247,66 @@ class _EventsScreenState extends State<EventsScreen> {
           child: Card(
             margin: EdgeInsets.zero,
             shape: const RoundedRectangleBorder(),
-            child: DropdownButtonHideUnderline(
-              child: Column(children: [
-                SubHeader(loc.servers, height: 40.0),
-                Expanded(
-                  child: SingleChildScrollView(
-                    child: buildTreeView(context, setState: setState),
+            child: SafeArea(
+              child: DropdownButtonHideUnderline(
+                child: Column(children: [
+                  SubHeader(loc.servers, height: 40.0),
+                  Expanded(
+                    child: SingleChildScrollView(
+                      child: buildTreeView(context, setState: setState),
+                    ),
                   ),
-                ),
-                const SubHeader('Time filter', height: 24.0),
-                DropdownButton<EventsTimeFilter>(
-                  isExpanded: true,
-                  value: timeFilter,
-                  items: const [
-                    DropdownMenuItem(
-                      value: EventsTimeFilter.any,
-                      child: Text('Any'),
+                  const SubHeader('Time filter', height: 24.0),
+                  DropdownButton<EventsTimeFilter>(
+                    isExpanded: true,
+                    value: timeFilter,
+                    items: const [
+                      DropdownMenuItem(
+                        value: EventsTimeFilter.any,
+                        child: Text('Any'),
+                      ),
+                      DropdownMenuItem(
+                        value: EventsTimeFilter.lastHour,
+                        child: Text('Last hour'),
+                      ),
+                      DropdownMenuItem(
+                        value: EventsTimeFilter.last6Hours,
+                        child: Text('Last 6 hours'),
+                      ),
+                      DropdownMenuItem(
+                        value: EventsTimeFilter.last12Hours,
+                        child: Text('Last 12 hours'),
+                      ),
+                      DropdownMenuItem(
+                        value: EventsTimeFilter.last24Hours,
+                        child: Text('Last 24 hours'),
+                      ),
+                      // DropdownMenuItem(
+                      //   child: Text('Select time range'),
+                      //   value: EventsTimeFilter.custom,
+                      // ),
+                    ],
+                    onChanged: (v) => setState(
+                      () => timeFilter = v ?? timeFilter,
                     ),
-                    DropdownMenuItem(
-                      value: EventsTimeFilter.lastHour,
-                      child: Text('Last hour'),
-                    ),
-                    DropdownMenuItem(
-                      value: EventsTimeFilter.last6Hours,
-                      child: Text('Last 6 hours'),
-                    ),
-                    DropdownMenuItem(
-                      value: EventsTimeFilter.last12Hours,
-                      child: Text('Last 12 hours'),
-                    ),
-                    DropdownMenuItem(
-                      value: EventsTimeFilter.last24Hours,
-                      child: Text('Last 24 hours'),
-                    ),
-                    // DropdownMenuItem(
-                    //   child: Text('Select time range'),
-                    //   value: EventsTimeFilter.custom,
-                    // ),
-                  ],
-                  onChanged: (v) => setState(
-                    () => timeFilter = v ?? timeFilter,
                   ),
-                ),
-                const SubHeader('Minimum level', height: 24.0),
-                DropdownButton<EventsMinLevelFilter>(
-                  isExpanded: true,
-                  value: levelFilter,
-                  items: EventsMinLevelFilter.values.map((level) {
-                    return DropdownMenuItem(
-                      value: level,
-                      child: Text(level.name.uppercaseFirst()),
-                    );
-                  }).toList(),
-                  onChanged: (v) => setState(
-                    () => levelFilter = v ?? levelFilter,
+                  const SubHeader('Minimum level', height: 24.0),
+                  DropdownButton<EventsMinLevelFilter>(
+                    isExpanded: true,
+                    value: levelFilter,
+                    items: EventsMinLevelFilter.values.map((level) {
+                      return DropdownMenuItem(
+                        value: level,
+                        child: Text(level.name.uppercaseFirst()),
+                      );
+                    }).toList(),
+                    onChanged: (v) => setState(
+                      () => levelFilter = v ?? levelFilter,
+                    ),
                   ),
-                ),
-                const SizedBox(height: 16.0),
-              ]),
+                  const SizedBox(height: 16.0),
+                ]),
+              ),
             ),
           ),
         ),

--- a/lib/widgets/events/events_screen.dart
+++ b/lib/widgets/events/events_screen.dart
@@ -135,13 +135,13 @@ class _EventsScreenState extends State<EventsScreen> {
     final levelFilter = data['levelFilter'] as EventsMinLevelFilter;
     final disabledDevices = data['disabledDevices'] as List<String>;
 
-    final hourRange = {
-      EventsTimeFilter.last12Hours: 12,
-      EventsTimeFilter.last24Hours: 24,
-      EventsTimeFilter.last6Hours: 6,
-      EventsTimeFilter.lastHour: 1,
-      EventsTimeFilter.any: -1,
-    }[timeFilter]!;
+    final hourRange = switch (timeFilter) {
+      EventsTimeFilter.last12Hours => 12,
+      EventsTimeFilter.last24Hours => 24,
+      EventsTimeFilter.last6Hours => 6,
+      EventsTimeFilter.lastHour => 1,
+      EventsTimeFilter.any => -1,
+    };
 
     final now = DateTime.now();
     return events.values.expand((events) sync* {

--- a/lib/widgets/events/events_screen_desktop.dart
+++ b/lib/widgets/events/events_screen_desktop.dart
@@ -103,7 +103,7 @@ class EventsScreenDesktop extends StatelessWidget {
                     ),
                     _buildTilePart(
                       child: Text(
-                        '${settings.formatDate(event.updated.toLocal())} ${settings.formatTime(event.updated).toUpperCase()}',
+                        '${settings.formatDate(event.updated)} ${settings.formatTime(event.updated).toUpperCase()}',
                       ),
                       flex: 2,
                     ),

--- a/lib/widgets/events/events_screen_desktop.dart
+++ b/lib/widgets/events/events_screen_desktop.dart
@@ -57,61 +57,63 @@ class EventsScreenDesktop extends StatelessWidget {
     }
 
     return Material(
-      child: CustomScrollView(slivers: [
-        SliverPersistentHeader(delegate: _TableHeader(), pinned: true),
-        SliverFixedExtentList.builder(
-          itemCount: events.length,
-          itemExtent: 50.0,
-          addAutomaticKeepAlives: false,
-          addRepaintBoundaries: false,
-          itemBuilder: (context, index) {
-            final event = events.elementAt(index);
+      child: SafeArea(
+        child: CustomScrollView(slivers: [
+          SliverPersistentHeader(delegate: _TableHeader(), pinned: true),
+          SliverFixedExtentList.builder(
+            itemCount: events.length,
+            itemExtent: 50.0,
+            addAutomaticKeepAlives: false,
+            addRepaintBoundaries: false,
+            itemBuilder: (context, index) {
+              final event = events.elementAt(index);
 
-            return InkWell(
-              onTap: event.mediaURL == null
-                  ? null
-                  : () {
-                      debugPrint('Displaying event $event');
-                      Navigator.of(context).pushNamed(
-                        '/events',
-                        arguments: {'event': event, 'upcoming': events},
-                      );
-                    },
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 20.0),
-                child: Row(children: [
-                  Container(
-                    width: 40.0,
-                    height: 40.0,
-                    alignment: AlignmentDirectional.center,
-                    child: DownloadIndicator(event: event),
-                  ),
-                  _buildTilePart(child: Text(event.server.name), flex: 2),
-                  _buildTilePart(child: Text(event.deviceName)),
-                  _buildTilePart(
-                    child: Text(event.type.locale(context).uppercaseFirst()),
-                  ),
-                  _buildTilePart(
-                    child: Text(event.duration
-                        .humanReadableCompact(context)
-                        .uppercaseFirst()),
-                  ),
-                  _buildTilePart(
-                    child:
-                        Text(event.priority.locale(context).uppercaseFirst()),
-                  ),
-                  _buildTilePart(
-                    child: Text(
-                      '${settings.formatDate(event.updated.toLocal())} ${settings.formatTime(event.updated).toUpperCase()}',
+              return InkWell(
+                onTap: event.mediaURL == null
+                    ? null
+                    : () {
+                        debugPrint('Displaying event $event');
+                        Navigator.of(context).pushNamed(
+                          '/events',
+                          arguments: {'event': event, 'upcoming': events},
+                        );
+                      },
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20.0),
+                  child: Row(children: [
+                    Container(
+                      width: 40.0,
+                      height: 40.0,
+                      alignment: AlignmentDirectional.center,
+                      child: DownloadIndicator(event: event),
                     ),
-                    flex: 2,
-                  ),
-                ]),
-              ),
-            );
-          },
-        ),
-      ]),
+                    _buildTilePart(child: Text(event.server.name), flex: 2),
+                    _buildTilePart(child: Text(event.deviceName)),
+                    _buildTilePart(
+                      child: Text(event.type.locale(context).uppercaseFirst()),
+                    ),
+                    _buildTilePart(
+                      child: Text(event.duration
+                          .humanReadableCompact(context)
+                          .uppercaseFirst()),
+                    ),
+                    _buildTilePart(
+                      child:
+                          Text(event.priority.locale(context).uppercaseFirst()),
+                    ),
+                    _buildTilePart(
+                      child: Text(
+                        '${settings.formatDate(event.updated.toLocal())} ${settings.formatTime(event.updated).toUpperCase()}',
+                      ),
+                      flex: 2,
+                    ),
+                  ]),
+                ),
+              );
+            },
+          ),
+        ]),
+      ),
     );
   }
 }

--- a/lib/widgets/events/events_screen_mobile.dart
+++ b/lib/widgets/events/events_screen_mobile.dart
@@ -42,7 +42,8 @@ class EventsScreenMobile extends StatelessWidget {
     final loc = AppLocalizations.of(context);
 
     return Material(
-      child: RefreshIndicator(
+      color: Colors.blue,
+      child: RefreshIndicator.adaptive(
         onRefresh: refresh,
         triggerMode: RefreshIndicatorTriggerMode.anywhere,
         child: ListView.builder(
@@ -57,7 +58,7 @@ class EventsScreenMobile extends StatelessWidget {
             return IgnorePointer(
               ignoring: !server.online || !isLoaded,
               child: ExpansionTile(
-                initiallyExpanded: servers.servers.length.compareTo(1) == 0,
+                initiallyExpanded: servers.servers.length == 1,
                 maintainState: true,
                 leading: CircleAvatar(
                   backgroundColor: Colors.transparent,

--- a/lib/widgets/events/events_screen_mobile.dart
+++ b/lib/widgets/events/events_screen_mobile.dart
@@ -42,7 +42,6 @@ class EventsScreenMobile extends StatelessWidget {
     final loc = AppLocalizations.of(context);
 
     return Material(
-      color: Colors.blue,
       child: RefreshIndicator.adaptive(
         onRefresh: refresh,
         triggerMode: RefreshIndicatorTriggerMode.anywhere,

--- a/lib/widgets/events_timeline/desktop/timeline.dart
+++ b/lib/widgets/events_timeline/desktop/timeline.dart
@@ -24,6 +24,7 @@ import 'package:bluecherry_client/models/device.dart';
 import 'package:bluecherry_client/models/event.dart';
 import 'package:bluecherry_client/providers/settings_provider.dart';
 import 'package:bluecherry_client/utils/extensions.dart';
+import 'package:bluecherry_client/utils/methods.dart';
 import 'package:bluecherry_client/widgets/device_grid/device_grid.dart'
     show calculateCrossAxisCount;
 import 'package:bluecherry_client/widgets/events_timeline/desktop/timeline_card.dart';
@@ -371,9 +372,12 @@ class Timeline extends ChangeNotifier {
   }
 
   void play([TimelineEvent? event]) {
+    timer?.cancel();
     timer ??= Timer.periodic(Duration(milliseconds: 1000 ~/ _speed), (timer) {
-      if (event == null) currentPosition += const Duration(seconds: 1);
-      notifyListeners();
+      if (event == null) {
+        currentPosition += const Duration(seconds: 1);
+        notifyListeners();
+      }
 
       forEachEvent((tile, e) {
         if (tile.videoController.isPlaying) return;
@@ -628,20 +632,24 @@ class _TimelineEventsViewState extends State<TimelineEventsView> {
                         }
                       }
                     },
-                    child: SingleChildScrollView(
+                    child: Scrollbar(
                       controller: timeline.zoomController,
-                      scrollDirection: Axis.horizontal,
-                      child: SizedBox(
-                        width: tileWidth,
-                        child: Column(children: [
-                          _TimelineHours(hourWidth: hourWidth),
-                          ...timeline.tiles.map((tile) {
-                            return _TimelineTile(
-                              key: ValueKey(tile),
-                              tile: tile,
-                            );
-                          }),
-                        ]),
+                      thumbVisibility: isMobilePlatform || kIsWeb,
+                      child: SingleChildScrollView(
+                        controller: timeline.zoomController,
+                        scrollDirection: Axis.horizontal,
+                        child: SizedBox(
+                          width: tileWidth,
+                          child: Column(children: [
+                            _TimelineHours(hourWidth: hourWidth),
+                            ...timeline.tiles.map((tile) {
+                              return _TimelineTile(
+                                key: ValueKey(tile),
+                                tile: tile,
+                              );
+                            }),
+                          ]),
+                        ),
                       ),
                     ),
                   ),

--- a/lib/widgets/events_timeline/desktop/timeline_sidebar.dart
+++ b/lib/widgets/events_timeline/desktop/timeline_sidebar.dart
@@ -104,8 +104,6 @@ class _TimelineSidebarState extends State<TimelineSidebar> {
       return const SizedBox.shrink();
     }
     final state = eventsPlaybackScreenKey.currentState!;
-
-    final theme = Theme.of(context);
     final servers = state.devices.keys.map((d) => d.server).toSet();
 
     return TreeView(
@@ -119,57 +117,44 @@ class _TimelineSidebarState extends State<TimelineSidebar> {
             server.devices.where(state.realDevices.containsKey).sorted();
 
         return TreeNode(
-          content: Row(children: [
-            buildCheckbox(
-              value: isOffline ||
-                      !widget.timeline.tiles.any(
-                        (tile) => server.devices.contains(tile.device),
-                      )
-                  ? false
-                  : isTriState
-                      ? null
-                      : true,
-              isError: isOffline,
-              onChanged: (v) {
-                if (isTriState || v == null || !v) {
-                  for (final device in serverDevices) {
-                    if (widget.timeline.tiles
-                        .any((tile) => tile.device == device)) {
-                      widget.timeline.removeTile(
-                        widget.timeline.tiles
-                            .firstWhere((tile) => tile.device == device),
-                      );
-                    }
-                  }
-                } else {
-                  for (final device in serverDevices) {
-                    widget.timeline.add([
-                      state.realDevices.entries
-                          .firstWhere((e) => e.key == device)
-                          .buildTimelineTile(context),
-                    ]);
+          content: buildCheckbox(
+            value: isOffline ||
+                    !widget.timeline.tiles.any(
+                      (tile) => server.devices.contains(tile.device),
+                    )
+                ? false
+                : isTriState
+                    ? null
+                    : true,
+            isError: isOffline,
+            onChanged: (v) {
+              if (isTriState || v == null || !v) {
+                for (final device in serverDevices) {
+                  if (widget.timeline.tiles
+                      .any((tile) => tile.device == device)) {
+                    widget.timeline.removeTile(
+                      widget.timeline.tiles
+                          .firstWhere((tile) => tile.device == device),
+                    );
                   }
                 }
+              } else {
+                for (final device in serverDevices) {
+                  widget.timeline.add([
+                    state.realDevices.entries
+                        .firstWhere((e) => e.key == device)
+                        .buildTimelineTile(context),
+                  ]);
+                }
+              }
 
-                setState(() {});
-              },
-              checkboxScale: checkboxScale,
-            ),
-            SizedBox(width: gapCheckboxText),
-            Expanded(
-              child: Text(
-                server.name,
-                overflow: TextOverflow.ellipsis,
-                maxLines: 1,
-                softWrap: false,
-              ),
-            ),
-            Text(
-              '${serverDevices.length}',
-              style: theme.textTheme.labelSmall,
-            ),
-            const SizedBox(width: 10.0),
-          ]),
+              setState(() {});
+            },
+            checkboxScale: checkboxScale,
+            text: server.name,
+            secondaryText: '${serverDevices.length}',
+            gapCheckboxText: gapCheckboxText,
+          ),
           children: () {
             if (isOffline) {
               return <TreeNode>[];
@@ -181,52 +166,39 @@ class _TimelineSidebarState extends State<TimelineSidebar> {
                 final eventsForDevice = state.devices[device];
 
                 return TreeNode(
-                  content: Row(children: [
-                    IgnorePointer(
-                      ignoring: !device.status,
-                      child: buildCheckbox(
-                        value: device.status ? enabled : false,
-                        isError: !device.status,
-                        onChanged: (v) {
-                          if (!device.status) return;
+                  content: IgnorePointer(
+                    ignoring: !device.status,
+                    child: buildCheckbox(
+                      value: device.status ? enabled : false,
+                      isError: !device.status,
+                      onChanged: (v) {
+                        if (!device.status) return;
 
-                          if (enabled && state.disabledDevices.length < 4) {
-                            widget.timeline.removeTile(
-                              widget.timeline.tiles.firstWhere(
-                                (tile) => tile.device == device,
-                              ),
-                            );
-                          } else if (state.realDevices.entries
-                                  .any((e) => e.key == device) &&
-                              !enabled) {
-                            widget.timeline.add([
-                              state.realDevices.entries
-                                  .firstWhere((e) => e.key == device)
-                                  .buildTimelineTile(context),
-                            ]);
-                          }
-                          setState(() {});
-                        },
-                        checkboxScale: checkboxScale,
-                      ),
+                        if (enabled && state.disabledDevices.length < 4) {
+                          widget.timeline.removeTile(
+                            widget.timeline.tiles.firstWhere(
+                              (tile) => tile.device == device,
+                            ),
+                          );
+                        } else if (state.realDevices.entries
+                                .any((e) => e.key == device) &&
+                            !enabled) {
+                          widget.timeline.add([
+                            state.realDevices.entries
+                                .firstWhere((e) => e.key == device)
+                                .buildTimelineTile(context),
+                          ]);
+                        }
+                        setState(() {});
+                      },
+                      checkboxScale: checkboxScale,
+                      text: device.name,
+                      secondaryText: eventsForDevice != null
+                          ? ' (${eventsForDevice.length})'
+                          : null,
+                      gapCheckboxText: gapCheckboxText,
                     ),
-                    SizedBox(width: gapCheckboxText),
-                    Flexible(
-                      child: Text(
-                        device.name,
-                        overflow: TextOverflow.ellipsis,
-                        maxLines: 1,
-                        softWrap: false,
-                      ),
-                    ),
-                    if (eventsForDevice != null) ...[
-                      Text(
-                        ' (${eventsForDevice.length})',
-                        style: theme.textTheme.labelSmall,
-                      ),
-                      const SizedBox(width: 10.0),
-                    ],
-                  ]),
+                  ),
                 );
               }).toList();
             }

--- a/lib/widgets/events_timeline/events_playback.dart
+++ b/lib/widgets/events_timeline/events_playback.dart
@@ -137,22 +137,14 @@ class _EventsPlaybackState extends State<EventsPlayback> {
         // If there is already an event that conflicts with this one in time, do
         // not add it
         if (realDevices[device]!.any((e) {
-          return e.published.isInBetween(
-                event.published,
-                event.published.add(event.duration),
-              ) ||
-              e.published.add(e.duration).isInBetween(
-                    event.published,
-                    event.published.add(event.duration),
-                  ) ||
-              event.published.isInBetween(
-                e.published,
-                e.published.add(e.duration),
-              ) ||
-              event.published.add(event.duration).isInBetween(
-                    e.published,
-                    e.published.add(e.duration),
-                  );
+          return e.published.isInBetween(event.published, event.updated,
+                  allowSameMoment: true) ||
+              e.updated.isInBetween(event.published, event.updated,
+                  allowSameMoment: true) ||
+              event.published
+                  .isInBetween(e.published, e.updated, allowSameMoment: true) ||
+              event.updated
+                  .isInBetween(e.published, e.updated, allowSameMoment: true);
         })) continue;
 
         realDevices[device] ??= [];

--- a/lib/widgets/events_timeline/events_playback.dart
+++ b/lib/widgets/events_timeline/events_playback.dart
@@ -25,7 +25,6 @@ import 'package:bluecherry_client/models/event.dart';
 import 'package:bluecherry_client/providers/downloads_provider.dart';
 import 'package:bluecherry_client/providers/home_provider.dart';
 import 'package:bluecherry_client/providers/server_provider.dart';
-import 'package:bluecherry_client/utils/constants.dart';
 import 'package:bluecherry_client/utils/extensions.dart';
 import 'package:bluecherry_client/widgets/events_timeline/desktop/timeline.dart';
 import 'package:bluecherry_client/widgets/events_timeline/mobile/timeline_device_view.dart';

--- a/lib/widgets/events_timeline/events_playback.dart
+++ b/lib/widgets/events_timeline/events_playback.dart
@@ -232,7 +232,9 @@ class _EventsPlaybackState extends State<EventsPlayback> {
       child: LayoutBuilder(builder: (context, constraints) {
         final hasDrawer = Scaffold.hasDrawer(context);
 
-        if (hasDrawer || constraints.maxWidth < kMobileBreakpoint.width) {
+        if (hasDrawer ||
+            // special case: the width is less than the mobile breakpoint
+            constraints.maxWidth < 630.0 /* kMobileBreakpoint.width */) {
           if (timeline == null) {
             return SafeArea(
               child: Padding(

--- a/lib/widgets/events_timeline/events_playback.dart
+++ b/lib/widgets/events_timeline/events_playback.dart
@@ -179,12 +179,14 @@ class _EventsPlaybackState extends State<EventsPlayback> {
 
     home.notLoading(UnityLoadingReason.fetchingEventsPlayback);
 
-    setState(() {
-      timeline = Timeline(
-        tiles: parsedTiles.toList(),
-        date: date,
-      );
-    });
+    if (mounted) {
+      setState(() {
+        timeline = Timeline(
+          tiles: parsedTiles.toList(),
+          date: date,
+        );
+      });
+    }
   }
 
   @override
@@ -246,9 +248,11 @@ class _EventsPlaybackState extends State<EventsPlayback> {
           }
           return SafeArea(child: TimelineDeviceView(timeline: timeline!));
         }
-        return TimelineEventsView(
-          // timeline: kDebugMode ? Timeline.fakeTimeline : timeline,
-          timeline: timeline,
+        return SafeArea(
+          child: TimelineEventsView(
+            // timeline: kDebugMode ? Timeline.fakeTimeline : timeline,
+            timeline: timeline,
+          ),
         );
       }),
     );

--- a/lib/widgets/events_timeline/mobile/timeline_device_view.dart
+++ b/lib/widgets/events_timeline/mobile/timeline_device_view.dart
@@ -66,6 +66,9 @@ class _TimelineDeviceViewState extends State<TimelineDeviceView> {
   }
 
   int lastEventIndex = -1;
+  bool get isFirstEvent => lastEventIndex <= 0;
+  bool get isLastEvent =>
+      lastEventIndex.isNegative || lastEventIndex == tile!.events.length - 1;
 
   /// Whether the user is scrolling the timeline. If true, [ensureScrollPosition]
   /// will not execute to avoid conflicts
@@ -259,7 +262,7 @@ class _TimelineDeviceViewState extends State<TimelineDeviceView> {
 
     isScrolling = false;
     if (wasPlayingOnScroll) {
-      widget.timeline.play();
+      widget.timeline.play(currentEvent);
     }
   }
 
@@ -466,8 +469,8 @@ class _TimelineDeviceViewState extends State<TimelineDeviceView> {
         ),
         IconButton(
           icon: const Icon(Icons.skip_previous),
-          tooltip: loc.previous,
-          onPressed: lastEventIndex <= 0
+          tooltip: isFirstEvent ? null : loc.previous,
+          onPressed: isFirstEvent
               ? null
               : () {
                   setEvent(tile!.events.elementAt(lastEventIndex - 1));
@@ -499,12 +502,11 @@ class _TimelineDeviceViewState extends State<TimelineDeviceView> {
         const SizedBox(width: 6.0),
         IconButton(
           icon: const Icon(Icons.skip_next),
-          tooltip: loc.next,
-          onPressed: lastEventIndex.isNegative ||
-                  lastEventIndex == tile!.events.length - 1
+          tooltip: isLastEvent ? null : loc.next,
+          onPressed: isLastEvent
               ? null
               : () {
-                  setEvent(tile.events.elementAt(lastEventIndex + 1));
+                  setEvent(tile!.events.elementAt(lastEventIndex + 1));
                 },
         ),
         Expanded(

--- a/lib/widgets/home.dart
+++ b/lib/widgets/home.dart
@@ -19,6 +19,7 @@
 
 import 'package:animations/animations.dart';
 import 'package:bluecherry_client/providers/home_provider.dart';
+import 'package:bluecherry_client/utils/constants.dart';
 import 'package:bluecherry_client/utils/methods.dart';
 import 'package:bluecherry_client/widgets/add_server_wizard.dart';
 import 'package:bluecherry_client/widgets/desktop_buttons.dart';
@@ -33,11 +34,14 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 
 class NavigatorData {
+  /// The tab that this navigator data represents.
+  final UnityTab tab;
   final IconData icon;
   final IconData selectedIcon;
   final String text;
 
   const NavigatorData({
+    required this.tab,
     required this.icon,
     required this.selectedIcon,
     required this.text,
@@ -45,39 +49,48 @@ class NavigatorData {
 
   static List<NavigatorData> of(BuildContext context) {
     final loc = AppLocalizations.of(context);
+    final screenSize = MediaQuery.of(context).size;
 
     return [
       NavigatorData(
+        tab: UnityTab.deviceGrid,
         icon: Icons.window_outlined,
         selectedIcon: Icons.window,
         text: loc.screens,
       ),
       NavigatorData(
+        tab: UnityTab.eventsPlayback,
         icon: Icons.subscriptions_outlined,
         selectedIcon: Icons.subscriptions,
         text: loc.eventsTimeline,
       ),
+      if (screenSize.width <= kMobileBreakpoint.width)
+        NavigatorData(
+          tab: UnityTab.directCameraScreen,
+          icon: Icons.videocam_outlined,
+          selectedIcon: Icons.videocam,
+          text: loc.directCamera,
+        ),
       NavigatorData(
-        icon: Icons.videocam_outlined,
-        selectedIcon: Icons.videocam,
-        text: loc.directCamera,
-      ),
-      NavigatorData(
+        tab: UnityTab.eventsScreen,
         icon: Icons.featured_play_list_outlined,
         selectedIcon: Icons.featured_play_list,
         text: loc.eventBrowser,
       ),
       NavigatorData(
+        tab: UnityTab.addServer,
         icon: Icons.dns_outlined,
         selectedIcon: Icons.dns,
         text: loc.addServer,
       ),
       NavigatorData(
+        tab: UnityTab.downloads,
         icon: Icons.download_outlined,
         selectedIcon: Icons.download,
         text: loc.downloads,
       ),
       NavigatorData(
+        tab: UnityTab.settings,
         icon: Icons.settings_outlined,
         selectedIcon: Icons.settings,
         text: loc.settings,
@@ -154,12 +167,15 @@ class _MobileHomeState extends State<Home> {
                         return const DirectCameraScreen();
                       },
                       UnityTab.eventsPlayback: EventsPlayback.new,
-                      UnityTab.eventsScreen: () => EventsScreen(
-                            key: eventsScreenKey,
-                          ),
-                      UnityTab.addServer: () => AddServerWizard(
-                            onFinish: () async => home.setTab(0, context),
-                          ),
+                      UnityTab.eventsScreen: () {
+                        return EventsScreen(key: eventsScreenKey);
+                      },
+                      UnityTab.addServer: () {
+                        return AddServerWizard(
+                          onFinish: () async =>
+                              home.setTab(UnityTab.deviceGrid, context),
+                        );
+                      },
                       UnityTab.downloads: () {
                         return DownloadsManagerScreen(
                           initiallyExpandedEventId:
@@ -167,7 +183,7 @@ class _MobileHomeState extends State<Home> {
                         );
                       },
                       UnityTab.settings: () => const Settings(),
-                    }[UnityTab.values[tab]]!(),
+                    }[tab]!(),
                   ),
                 ),
               ),
@@ -202,8 +218,7 @@ class _MobileHomeState extends State<Home> {
           ),
           const SizedBox(height: 8.0),
           ...navData.map((data) {
-            final index = navData.indexOf(data);
-            final isSelected = tab == index;
+            final isSelected = tab == data.tab;
 
             final icon = isSelected ? data.selectedIcon : data.icon;
             final text = data.text;
@@ -227,8 +242,8 @@ class _MobileHomeState extends State<Home> {
 
                     await Future.delayed(const Duration(milliseconds: 200));
                     navigator.pop();
-                    if (tab != index && mounted) {
-                      home.setTab(index, context);
+                    if (tab != data.tab && mounted) {
+                      home.setTab(data.tab, context);
                     }
                   },
                   child: DecoratedBox(
@@ -301,8 +316,7 @@ class _MobileHomeState extends State<Home> {
               color: theme.unselectedForegroundColor,
             ),
             destinations: navData.map((data) {
-              final index = navData.indexOf(data);
-              final isSelected = home.tab == index;
+              final isSelected = home.tab == data.tab;
 
               final icon = isSelected ? data.selectedIcon : data.icon;
               final text = data.text;
@@ -317,11 +331,13 @@ class _MobileHomeState extends State<Home> {
                 label: Text(text),
               );
             }).toList(),
-            selectedIndex: home.tab,
+            selectedIndex: navData.indexOf(navData.firstWhere(
+              (data) => data.tab == home.tab,
+              orElse: () => navData.first,
+            )),
             onDestinationSelected: (index) {
-              if (home.tab != index) {
-                home.setTab(index, context);
-              }
+              final nav = navData[index];
+              home.setTab(nav.tab, context);
             },
           ),
         ),

--- a/lib/widgets/home.dart
+++ b/lib/widgets/home.dart
@@ -161,29 +161,22 @@ class _MobileHomeState extends State<Home> {
                         child: child,
                       );
                     },
-                    child: <UnityTab, Widget Function()>{
-                      UnityTab.deviceGrid: () => const DeviceGrid(),
-                      UnityTab.directCameraScreen: () {
-                        return const DirectCameraScreen();
-                      },
-                      UnityTab.eventsPlayback: EventsPlayback.new,
-                      UnityTab.eventsScreen: () {
-                        return EventsScreen(key: eventsScreenKey);
-                      },
-                      UnityTab.addServer: () {
-                        return AddServerWizard(
+                    child: switch (tab) {
+                      UnityTab.deviceGrid => const DeviceGrid(),
+                      UnityTab.directCameraScreen => const DirectCameraScreen(),
+                      UnityTab.eventsPlayback => EventsPlayback(),
+                      UnityTab.eventsScreen =>
+                        EventsScreen(key: eventsScreenKey),
+                      UnityTab.addServer => AddServerWizard(
                           onFinish: () async =>
                               home.setTab(UnityTab.deviceGrid, context),
-                        );
-                      },
-                      UnityTab.downloads: () {
-                        return DownloadsManagerScreen(
+                        ),
+                      UnityTab.downloads => DownloadsManagerScreen(
                           initiallyExpandedEventId:
                               home.initiallyExpandedDownloadEventId,
-                        );
-                      },
-                      UnityTab.settings: () => const Settings(),
-                    }[tab]!(),
+                        ),
+                      UnityTab.settings => const Settings(),
+                    },
                   ),
                 ),
               ),

--- a/lib/widgets/hover_button.dart
+++ b/lib/widgets/hover_button.dart
@@ -27,6 +27,8 @@ class HoverButton extends StatefulWidget {
     this.onLongPressEnd,
     this.onLongPressDown,
     this.onLongPressStart,
+    this.onLongPressCancel,
+    this.onLongPressUp,
     this.onHorizontalDragStart,
     this.onHorizontalDragUpdate,
     this.onHorizontalDragEnd,
@@ -66,6 +68,8 @@ class HoverButton extends StatefulWidget {
   final GestureLongPressStartCallback? onLongPressStart;
   final GestureLongPressEndCallback? onLongPressEnd;
   final GestureLongPressDownCallback? onLongPressDown;
+  final GestureLongPressCancelCallback? onLongPressCancel;
+  final VoidCallback? onLongPressUp;
 
   final VoidCallback? onPressed;
   final VoidCallback? onTapUp;
@@ -308,6 +312,8 @@ class HoverButtonState extends State<HoverButton> {
             }
           : null,
       onLongPressDown: widget.onLongPressDown,
+      onLongPressCancel: widget.onLongPressCancel,
+      onLongPressUp: widget.onLongPressUp,
       onHorizontalDragStart: widget.onHorizontalDragStart,
       onHorizontalDragUpdate: widget.onHorizontalDragUpdate,
       onHorizontalDragEnd: widget.onHorizontalDragEnd,

--- a/lib/widgets/misc.dart
+++ b/lib/widgets/misc.dart
@@ -205,7 +205,7 @@ class SubHeader extends StatelessWidget {
     this.subtextStyle,
     this.trailing,
     super.key,
-    this.padding = const EdgeInsets.symmetric(horizontal: 16.0),
+    this.padding = const EdgeInsetsDirectional.symmetric(horizontal: 16.0),
     this.height = 56.0,
   });
 
@@ -213,11 +213,8 @@ class SubHeader extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    final isInCard = context.findAncestorWidgetOfExactType<Card>() != null ||
-        context.findAncestorWidgetOfExactType<AlertDialog>() != null;
-
     return Material(
-      type: isInCard ? MaterialType.transparency : MaterialType.canvas,
+      type: MaterialType.transparency,
       child: Container(
         height: height,
         alignment: AlignmentDirectional.centerStart,

--- a/lib/widgets/settings/server_tile.dart
+++ b/lib/widgets/settings/server_tile.dart
@@ -34,7 +34,7 @@ class ServersList extends StatelessWidget {
     void addServersScreen() {
       home
         ..automaticallyGoToAddServersScreen = true
-        ..setTab(UnityTab.addServer.index, context);
+        ..setTab(UnityTab.addServer, context);
     }
 
     return LayoutBuilder(builder: (context, consts) {
@@ -387,9 +387,7 @@ Future showServerMenu({
       const PopupMenuDivider(height: 1.0),
       PopupMenuItem(
         child: Text(loc.browseEvents),
-        onTap: () {
-          home.setTab(UnityTab.eventsScreen.index, context);
-        },
+        onTap: () => home.setTab(UnityTab.eventsScreen, context),
       ),
       PopupMenuItem(
         child: Text(loc.configureServer),

--- a/lib/widgets/settings/settings.dart
+++ b/lib/widgets/settings/settings.dart
@@ -100,11 +100,11 @@ class _SettingsState extends State<Settings> {
                   leading: CircleAvatar(
                     backgroundColor: Colors.transparent,
                     foregroundColor: theme.iconTheme.color,
-                    child: Icon({
-                      ThemeMode.system: Icons.brightness_auto,
-                      ThemeMode.light: Icons.light_mode,
-                      ThemeMode.dark: Icons.dark_mode,
-                    }[e]!),
+                    child: Icon(switch (e) {
+                      ThemeMode.system => Icons.brightness_auto,
+                      ThemeMode.light => Icons.light_mode,
+                      ThemeMode.dark => Icons.dark_mode,
+                    }),
                   ),
                   onTap: () {
                     settings.themeMode = e;
@@ -116,11 +116,11 @@ class _SettingsState extends State<Settings> {
                       settings.themeMode = e;
                     },
                   ),
-                  title: Text({
-                    ThemeMode.system: loc.system,
-                    ThemeMode.light: loc.light,
-                    ThemeMode.dark: loc.dark,
-                  }[e]!),
+                  title: Text(switch (e) {
+                    ThemeMode.system => loc.system,
+                    ThemeMode.light => loc.light,
+                    ThemeMode.dark => loc.dark,
+                  }),
                 );
               }).toList()),
               if (update.isUpdatingSupported) ...[

--- a/packages/unity_video_player/unity_video_player_main/lib/unity_video_player_main.dart
+++ b/packages/unity_video_player/unity_video_player_main/lib/unity_video_player_main.dart
@@ -56,11 +56,13 @@ class UnityVideoPlayerMediaKitInterface extends UnityVideoPlayerInterface {
               player: (player as UnityVideoPlayerMediaKit).mkPlayer,
               videoController: player.mkVideoController,
               color: color,
-              fit: {
-                UnityVideoFit.contain: BoxFit.contain,
-                UnityVideoFit.cover: BoxFit.cover,
-                UnityVideoFit.fill: BoxFit.fill,
-              }[fit]!,
+              fit: () {
+                return switch (fit) {
+                  UnityVideoFit.contain => BoxFit.contain,
+                  UnityVideoFit.cover => BoxFit.cover,
+                  UnityVideoFit.fill => BoxFit.fill,
+                };
+              }(),
             ),
           ),
         ),

--- a/packages/unity_video_player/unity_video_player_main/pubspec.yaml
+++ b/packages/unity_video_player/unity_video_player_main/pubspec.yaml
@@ -6,7 +6,7 @@ homepage:
 publish_to: none
 
 environment:
-  sdk: '>=2.18.5 <3.0.0'
+  sdk: ">=3.0.0 <4.0.0"
   flutter: ">=1.17.0"
 
 dependencies:

--- a/packages/unity_video_player/unity_video_player_platform_interface/lib/unity_video_player_platform_interface.dart
+++ b/packages/unity_video_player/unity_video_player_platform_interface/lib/unity_video_player_platform_interface.dart
@@ -222,6 +222,9 @@ class UnityVideoViewState extends State<UnityVideoView> {
       _onErrorSubscription.cancel();
       _onDurationUpdateSubscription.cancel();
       _fpsSubscription.cancel();
+      _oldImageTimer?.cancel();
+      _lastImageTime = null;
+      _isImageOld = false;
 
       _onErrorSubscription = widget.player.onError.listen(_onError);
       _onDurationUpdateSubscription =
@@ -255,11 +258,7 @@ class UnityVideoViewState extends State<UnityVideoView> {
   }
 
   void _onPositionUpdate(Duration duration) {
-    if (mounted) {
-      setState(() {
-        error = null;
-      });
-    }
+    if (mounted) setState(() => error = null);
   }
 
   void _onFpsUpdate(double fps) {
@@ -297,10 +296,7 @@ class UnityVideoViewState extends State<UnityVideoView> {
     );
 
     if (widget.heroTag != null) {
-      return Hero(
-        tag: widget.heroTag,
-        child: videoView,
-      );
+      return Hero(tag: widget.heroTag, child: videoView);
     }
 
     return videoView;

--- a/packages/unity_video_player/unity_video_player_platform_interface/lib/unity_video_player_platform_interface.dart
+++ b/packages/unity_video_player/unity_video_player_platform_interface/lib/unity_video_player_platform_interface.dart
@@ -332,14 +332,14 @@ enum UnityVideoQuality {
 
   /// Returns the video quality for the video height
   static UnityVideoQuality qualityForResolutionY(int? height) {
-    return {
-          1080: p1080,
-          720: p720,
-          480: p480,
-          360: p360,
-          240: p240,
-        }[height] ??
-        UnityVideoQuality.p480;
+    return switch(height) {
+      1080 => p1080,
+      720 => p720,
+      480 => p480,
+      360 => p360,
+      240 => p240,
+      _ => p480,
+    };
   }
 }
 

--- a/packages/unity_video_player/unity_video_player_platform_interface/lib/unity_video_player_platform_interface.dart
+++ b/packages/unity_video_player/unity_video_player_platform_interface/lib/unity_video_player_platform_interface.dart
@@ -332,7 +332,7 @@ enum UnityVideoQuality {
 
   /// Returns the video quality for the video height
   static UnityVideoQuality qualityForResolutionY(int? height) {
-    return switch(height) {
+    return switch (height) {
       1080 => p1080,
       720 => p720,
       480 => p480,


### PR DESCRIPTION
- [x] Do not show "Direct Cameras" screen on large screens
- [x] Tooltips are shown immediately on desktop
- [x] On Windows, the default download directory paths to the system `Videos/` directory
- [x] Improve the timeline view for larger screens with touch.
     Now, a scrollbar is always visible when running on mobile. On desktop, it is possible to use the scrollbar when the mouse is close to the bottom.
- [x] On Android, the "tablet layout" no longer overflows the top status bar
- [x] In layout manager, "Open in a new window" is now only be available on desktop platforms
- [x] Reload all cameras when app comes from background to foreground
- [x] Events in the timeline are limited correctly
       They are not considered conflictious if they ended/started at the same moment. This is mostly true for `continuous` events.
- [x] Do not enforce any orientation on any screens - except for Device Grid screen.
       The device grid screen needs to be horizontal at any cases.
       On the other screens, it now defaults to the system orientation.