### PR TITLE
fix: do not encode device urls twice

### DIFF
--- a/lib/models/device.dart
+++ b/lib/models/device.dart
@@ -201,7 +201,7 @@ class Device {
   String get rtspURL {
     if (url != null) return url!;
 
-    return Uri.encodeFull(Uri(
+    return Uri(
       scheme: 'rtsp',
       userInfo: '${Uri.encodeComponent(server.login)}'
           ':'
@@ -209,13 +209,13 @@ class Device {
       host: server.ip,
       port: server.rtspPort,
       path: uri,
-    ).toString());
+    ).toString();
   }
 
   String get mjpegURL {
     if (url != null) return url!;
 
-    return Uri.encodeFull(Uri(
+    return Uri(
       scheme: 'https',
       userInfo: '${Uri.encodeComponent(server.login)}'
           ':'
@@ -227,13 +227,13 @@ class Device {
         'multipart': 'true',
         'id': '$id',
       },
-    ).toString());
+    ).toString();
   }
 
   String get hlsURL {
     if (url != null) return url!;
 
-    return Uri.encodeFull(Uri(
+    return Uri(
       scheme: 'https',
       userInfo: '${Uri.encodeComponent(server.login)}'
           ':'
@@ -241,7 +241,7 @@ class Device {
       host: server.ip,
       port: server.port,
       pathSegments: ['hls', '$id', 'index.m3u8'],
-    ).toString());
+    ).toString();
   }
 
   Future<String> getHLSUrl([Device? device]) async {


### PR DESCRIPTION
Reverts this change: https://github.com/bluecherrydvr/unity/commit/7dd4749461052182bd8d515ed55e54143dfdde72#diff-3d1fd3f1563f3abfa0990e99b4f52ce2dd3e84770d433d9aef93e537c2501e59

Streams are not being encoded correctly if there is a special character,