### PR TITLE
Timeline view lag issue

### DIFF
--- a/lib/widgets/events/event_player_desktop.dart
+++ b/lib/widgets/events/event_player_desktop.dart
@@ -122,7 +122,7 @@ class _EventPlayerDesktopState extends State<EventPlayerDesktop> {
     playingSubscription.cancel();
     bufferSubscription.cancel();
     focusNode.dispose();
-    videoController.dispose();
+    if (widget.player == null) videoController.dispose();
     super.dispose();
   }
 
@@ -140,11 +140,14 @@ class _EventPlayerDesktopState extends State<EventPlayerDesktop> {
     debugPrint(mediaUrl);
 
     if (mediaUrl != videoController.dataSource) {
-      videoController
-        ..setDataSource(mediaUrl)
-        ..setVolume(volume)
-        ..setSpeed(speed);
+      debugPrint(
+        'Setting data source from ${videoController.dataSource} to $mediaUrl',
+      );
+      videoController.setDataSource(mediaUrl);
     }
+    videoController
+      ..setVolume(volume)
+      ..setSpeed(speed);
   }
 
   @override

--- a/lib/widgets/events/event_player_mobile.dart
+++ b/lib/widgets/events/event_player_mobile.dart
@@ -57,7 +57,12 @@ class _EventPlayerMobile extends StatefulWidget {
 }
 
 class __EventPlayerMobileState extends State<_EventPlayerMobile> {
-  late final videoController = widget.player ?? UnityVideoPlayer.create();
+  late final videoController = widget.player ??
+      UnityVideoPlayer.create(
+        enableCache: true,
+        // TODO(bdlukaa): determine quality based on settings
+        quality: UnityVideoQuality.p480,
+      );
 
   @override
   void initState() {

--- a/lib/widgets/events/event_player_mobile.dart
+++ b/lib/widgets/events/event_player_mobile.dart
@@ -87,9 +87,16 @@ class __EventPlayerMobileState extends State<_EventPlayerMobile> {
         : widget.event.mediaURL.toString();
 
     debugPrint(mediaUrl);
-    videoController
-      ..setDataSource(mediaUrl)
-      ..setSpeed(1.0);
+    if (videoController.dataSource != mediaUrl) {
+      debugPrint(
+        'Setting data source from ${videoController.dataSource} to $mediaUrl',
+      );
+      videoController
+        ..setDataSource(mediaUrl)
+        ..setSpeed(1.0);
+    } else {
+      videoController.setSpeed(1.0);
+    }
 
     super.didChangeDependencies();
   }

--- a/lib/widgets/events_timeline/desktop/timeline.dart
+++ b/lib/widgets/events_timeline/desktop/timeline.dart
@@ -60,6 +60,16 @@ class TimelineTile {
       enableCache: true,
       title: device.fullName,
     );
+    videoController.setMultipleDataSource(
+      events.map((event) => event.videoUrl),
+      autoPlay: false,
+    );
+  }
+
+  Event? currentEvent(DateTime currentDate) {
+    return events
+        .firstWhereOrNull((event) => event.isPlaying(currentDate))
+        ?.event;
   }
 }
 
@@ -174,30 +184,30 @@ class Timeline extends ChangeNotifier {
   void _eventCallback(TimelineTile tile, {bool notify = true}) {
     if (tile.videoController.duration <= Duration.zero) return;
 
-    final index = tiles.indexOf(tile);
+    // final index = tiles.indexOf(tile);
 
-    final bufferFactor = tile.videoController.currentBuffer.inMilliseconds /
-        tile.videoController.duration.inMilliseconds;
+    // final bufferFactor = tile.videoController.currentBuffer.inMilliseconds /
+    //     tile.videoController.duration.inMilliseconds;
 
-    // This only applies if the video is not buffered
-    if (bufferFactor < 1.0) {
-      if (tile.videoController.currentBuffer <
-          tile.videoController.currentPos) {
-        debugPrint('should pause for buffering');
-        pausedToBuffer.add(index);
-        stop();
-      } else if (pausedToBuffer.contains(index)) {
-        debugPrint('should play from buffering');
-        pausedToBuffer.remove(index);
+    // // This only applies if the video is not buffered
+    // if (bufferFactor < 1.0) {
+    //   if (tile.videoController.currentBuffer <
+    //       tile.videoController.currentPos) {
+    //     debugPrint('should pause $index for buffering');
+    //     pausedToBuffer.add(index);
+    //     stop();
+    //   } else if (pausedToBuffer.contains(index)) {
+    //     debugPrint('should play $index from buffering');
+    //     pausedToBuffer.remove(index);
 
-        if (pausedToBuffer.isEmpty) play();
-      }
-    } else if (pausedToBuffer.contains(index)) {
-      debugPrint('should play from buffering');
-      pausedToBuffer.remove(index);
+    //     if (pausedToBuffer.isEmpty) play();
+    //   }
+    // } else if (pausedToBuffer.contains(index)) {
+    //   debugPrint('should play $index from buffering');
+    //   pausedToBuffer.remove(index);
 
-      if (pausedToBuffer.isEmpty) play();
-    }
+    //   if (pausedToBuffer.isEmpty) play();
+    // }
     if (notify) notifyListeners();
   }
 
@@ -274,9 +284,10 @@ class Timeline extends ChangeNotifier {
     currentPosition = position;
     notifyListeners();
 
-    forEachEvent((tile, event) {
+    forEachEvent((tile, event) async {
       if (!event.isPlaying(currentDate)) return;
-      tile.videoController.setDataSource(event.videoUrl);
+      final eventIndex = tile.events.indexOf(event);
+      await tile.videoController.jumpToIndex(eventIndex);
 
       final position = event.position(currentDate);
       tile.videoController.seekTo(position);
@@ -319,6 +330,8 @@ class Timeline extends ChangeNotifier {
 
     play();
   }
+
+  Duration get period => Duration(milliseconds: 1000 ~/ _speed);
 
   final indicatorKey = GlobalKey(debugLabel: 'Indicator key');
   final zoomController = ScrollController(
@@ -377,6 +390,14 @@ class Timeline extends ChangeNotifier {
     timer?.cancel();
     timer = null;
 
+    forEachEvent((tile, event) {
+      tile.videoController.pause();
+
+      if (event.isPlaying(currentDate)) {
+        tile.videoController.seekTo(event.position(currentDate));
+      }
+    });
+
     for (final tile in tiles) {
       tile.videoController.pause();
     }
@@ -384,32 +405,45 @@ class Timeline extends ChangeNotifier {
   }
 
   void play([TimelineEvent? event]) {
+    debugPrint('Playing timeline with $period');
     timer?.cancel();
-    timer ??= Timer.periodic(Duration(milliseconds: 1000 ~/ _speed), (timer) {
+    timer ??= Timer.periodic(period, (timer) {
       if (event == null) {
-        currentPosition += const Duration(seconds: 1);
+        currentPosition += period;
         notifyListeners();
       }
 
       forEachEvent((tile, e) {
+        if (!tile.events.any((e) => e.isPlaying(currentDate))) {
+          tile.videoController.pause();
+          return;
+        }
+        if (!e.isPlaying(currentDate)) return;
+
+        final position = e.position(currentDate);
         if (tile.videoController.isPlaying) {
           // if the video is late by a lot of seconds, seek to the current position
-
-          if (e.position(currentDate) - tile.videoController.currentPos >
-              const Duration(seconds: 5)) {
-            debugPrint('Seeking ${tile.device} to ${e.position(currentDate)}');
-            tile.videoController.seekTo(e.position(currentDate));
+          final isLate = position - tile.videoController.currentPos >
+              const Duration(milliseconds: 3000);
+          if (isLate) {
+            tile.videoController.seekTo(position);
+            debugPrint('Device is late. Seeking ${tile.device} to $position');
           }
           return;
         }
 
         if ((event != null && event == e) || e.isPlaying(currentDate)) {
           if (event == null) {
-            tile.videoController.seekTo(e.position(currentDate));
+            tile.videoController.seekTo(position);
+            debugPrint('-- Seeking ${tile.device} to $position');
           }
-          if (!tile.videoController.isPlaying) tile.videoController.start();
+          if (!tile.videoController.isPlaying) {
+            tile.videoController.start();
+            debugPrint('Playing ${tile.device}');
+          }
         } else {
           tile.videoController.pause();
+          debugPrint('Pausing ${tile.device}');
         }
       });
     });
@@ -952,6 +986,12 @@ class _TimelineTile extends StatelessWidget {
                       //     : theme.colorScheme.primary,
                       color: theme.colorScheme.primary,
                       // color: theme.extension<UnityColors>()!.successColor,
+                      child: kDebugMode
+                          ? Text(
+                              '${tile.events.indexOf(event)}',
+                              style: const TextStyle(color: Colors.black),
+                            )
+                          : null,
                     ),
                   ),
               ]);

--- a/lib/widgets/events_timeline/desktop/timeline.dart
+++ b/lib/widgets/events_timeline/desktop/timeline.dart
@@ -675,7 +675,7 @@ class _TimelineEventsViewState extends State<TimelineEventsView> {
           ),
           ConstrainedBox(
             constraints: const BoxConstraints(
-              maxHeight: _kTimelineTileHeight * 4.5,
+              maxHeight: _kTimelineTileHeight * 5.0,
             ),
             child: LayoutBuilder(builder: (context, constraints) {
               final tileWidth =

--- a/lib/widgets/events_timeline/desktop/timeline.dart
+++ b/lib/widgets/events_timeline/desktop/timeline.dart
@@ -392,7 +392,16 @@ class Timeline extends ChangeNotifier {
       }
 
       forEachEvent((tile, e) {
-        if (tile.videoController.isPlaying) return;
+        if (tile.videoController.isPlaying) {
+          // if the video is late by a lot of seconds, seek to the current position
+
+          if (e.position(currentDate) - tile.videoController.currentPos >
+              const Duration(seconds: 5)) {
+            debugPrint('Seeking ${tile.device} to ${e.position(currentDate)}');
+            tile.videoController.seekTo(e.position(currentDate));
+          }
+          return;
+        }
 
         if ((event != null && event == e) || e.isPlaying(currentDate)) {
           if (event == null) {
@@ -474,7 +483,6 @@ class _TimelineEventsViewState extends State<TimelineEventsView> {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     final loc = AppLocalizations.of(context);
     final settings = context.watch<SettingsProvider>();
     final home = context.watch<HomeProvider>();
@@ -768,13 +776,15 @@ class _TimelineEventsViewState extends State<TimelineEventsView> {
                               child: Container(
                                 width: 8,
                                 height: 4,
-                                color: theme.colorScheme.onBackground,
+                                // color: theme.colorScheme.onBackground,
+                                color: Colors.black,
                               ),
                             ),
                             Expanded(
                               child: Container(
-                                color: theme.colorScheme.onBackground,
+                                // color: theme.colorScheme.onBackground,
                                 width: 1.8,
+                                color: Colors.black,
                               ),
                             ),
                           ]),
@@ -941,6 +951,7 @@ class _TimelineTile extends StatelessWidget {
                       //             1)]
                       //     : theme.colorScheme.primary,
                       color: theme.colorScheme.primary,
+                      // color: theme.extension<UnityColors>()!.successColor,
                     ),
                   ),
               ]);

--- a/lib/widgets/events_timeline/desktop/timeline_card.dart
+++ b/lib/widgets/events_timeline/desktop/timeline_card.dart
@@ -160,13 +160,14 @@ class _TimelineCardState extends State<TimelineCard> {
                   top: 36.0,
                   right: 0.0,
                   child: Text(
-                    'debug buffering: '
+                    'buffer: '
                     '${(widget.tile.videoController.currentBuffer.inMilliseconds / widget.tile.videoController.duration.inMilliseconds).toStringAsPrecision(2)}'
                     '\n${widget.tile.videoController.currentBuffer.humanReadableCompact(context)}',
                     style: theme.textTheme.labelLarge!.copyWith(
                       color: Colors.white,
                       shadows: outlinedText(strokeWidth: 0.75),
                     ),
+                    textAlign: TextAlign.end,
                   ),
                 ),
               PositionedDirectional(
@@ -228,11 +229,19 @@ class _TimelineCardState extends State<TimelineCard> {
                       ),
                       SquaredIconButton(
                         tooltip: loc.showFullscreenCamera,
-                        onPressed: () {
-                          Navigator.of(context).pushNamed(
+                        onPressed: () async {
+                          final isPlaying = widget.timeline.isPlaying;
+                          if (isPlaying) widget.timeline.stop();
+
+                          await Navigator.of(context).pushNamed(
                             '/events',
-                            arguments: {'event': currentEvent.event},
+                            arguments: {
+                              'event': currentEvent.event,
+                              'videoPlayer': widget.tile.videoController,
+                            },
                           );
+
+                          if (isPlaying) widget.timeline.play();
                         },
                         icon: Icon(
                           Icons.fullscreen,

--- a/lib/widgets/events_timeline/desktop/timeline_card.dart
+++ b/lib/widgets/events_timeline/desktop/timeline_card.dart
@@ -148,8 +148,9 @@ class _TimelineCardState extends State<TimelineCard> {
                 ),
               ),
               if (kDebugMode)
-                Align(
-                  alignment: AlignmentDirectional.topEnd,
+                Positioned(
+                  top: 36.0,
+                  right: 0.0,
                   child: Text(
                     'debug buffering: '
                     '${(widget.tile.videoController.currentBuffer.inMilliseconds / widget.tile.videoController.duration.inMilliseconds).toStringAsPrecision(2)}'
@@ -168,7 +169,7 @@ class _TimelineCardState extends State<TimelineCard> {
                 child: () {
                   if (controller.isBuffering) {
                     return const CircularProgressIndicator.adaptive(
-                      strokeWidth: 2.0,
+                      strokeWidth: 1.5,
                     );
                   }
                   if (isDownloaded || isDownloading || states.isHovering) {

--- a/lib/widgets/events_timeline/desktop/timeline_card.dart
+++ b/lib/widgets/events_timeline/desktop/timeline_card.dart
@@ -133,15 +133,23 @@ class _TimelineCardState extends State<TimelineCard> {
                     const TextSpan(text: '\n'),
                     if (states.isHovering)
                       TextSpan(
-                        text: currentEvent
-                            .position(widget.timeline.currentDate)
-                            .humanReadableCompact(context),
+                        text: kDebugMode
+                            ? currentEvent
+                                .position(widget.timeline.currentDate)
+                                .toString()
+                            : currentEvent
+                                .position(widget.timeline.currentDate)
+                                .humanReadableCompact(context),
                       ),
                     if (kDebugMode) ...[
                       const TextSpan(text: '\ndebug: '),
+                      TextSpan(text: controller.currentPos.toString()),
                       TextSpan(
                         text:
-                            controller.currentPos.humanReadableCompact(context),
+                            '\ndiff: ${currentEvent.position(widget.timeline.currentDate) - controller.currentPos}',
+                      ),
+                      TextSpan(
+                        text: '\nindex: ${events.indexOf(currentEvent)}',
                       ),
                     ],
                   ],

--- a/packages/unity_video_player/unity_video_player_flutter/lib/unity_video_player_flutter.dart
+++ b/packages/unity_video_player/unity_video_player_flutter/lib/unity_video_player_flutter.dart
@@ -160,9 +160,17 @@ class UnityVideoPlayerFlutter extends UnityVideoPlayer {
   }
 
   @override
-  Future<void> setMultipleDataSource(List<String> url, {bool autoPlay = true}) {
+  Future<void> setMultipleDataSource(Iterable<String> url,
+      {bool autoPlay = true}) {
     throw UnsupportedError(
       'setMultipleDataSource is not supported on this platform',
+    );
+  }
+
+  @override
+  Future<void> jumpToIndex(int index) {
+    throw UnsupportedError(
+      'jumpToIndex is not supported on this platform',
     );
   }
 

--- a/packages/unity_video_player/unity_video_player_main/lib/unity_video_player_main.dart
+++ b/packages/unity_video_player/unity_video_player_main/lib/unity_video_player_main.dart
@@ -218,6 +218,7 @@ class UnityVideoPlayerMediaKit extends UnityVideoPlayer {
       platform.setProperty('force-seekable', 'yes');
 
       if (enableCache) {
+        debugPrint('Cache is enabled');
         // https://mpv.io/manual/stable/#options-cache
         platform
           ..setProperty('cache', 'yes')
@@ -234,8 +235,11 @@ class UnityVideoPlayerMediaKit extends UnityVideoPlayer {
             ..setProperty('cache-dir', value.path);
         });
 
-        // https://mpv.io/manual/master/#options-gapless-audio
-        platform.setProperty('gapless-audio', 'yes');
+        platform
+          // https://mpv.io/manual/master/#options-gapless-audio
+          ..setProperty('gapless-audio', 'yes')
+          // https://mpv.io/manual/master/#options-prefetch-playlist
+          ..setProperty('prefetch-playlist', 'yes');
       } else {
         platform
           ..setProperty('cache', 'no')

--- a/packages/unity_video_player/unity_video_player_main/lib/unity_video_player_main.dart
+++ b/packages/unity_video_player/unity_video_player_main/lib/unity_video_player_main.dart
@@ -224,12 +224,18 @@ class UnityVideoPlayerMediaKit extends UnityVideoPlayer {
           // https://mpv.io/manual/stable/#options-cache-pause-initial
           ..setProperty('cache-pause-initial', 'yes')
           // https://mpv.io/manual/stable/#options-cache-pause-wait
-          ..setProperty('cache-pause-wait', '1');
+          ..setProperty('cache-pause-wait', '1')
+          ..setProperty('cache-pause', 'no')
+          // https://mpv.io/manual/stable/#options-cache-secs
+          ..setProperty('cache-secs', '13');
         getTemporaryDirectory().then((value) {
           platform
             ..setProperty('cache-on-disk', 'yes')
             ..setProperty('cache-dir', value.path);
         });
+
+        // https://mpv.io/manual/master/#options-gapless-audio
+        platform.setProperty('gapless-audio', 'yes');
       } else {
         platform
           ..setProperty('cache', 'no')
@@ -307,7 +313,7 @@ class UnityVideoPlayerMediaKit extends UnityVideoPlayer {
 
   @override
   Future<void> setMultipleDataSource(
-    List<String> url, {
+    Iterable<String> url, {
     bool autoPlay = true,
   }) {
     return ensureVideoControllerInitialized((controller) async {
@@ -315,6 +321,13 @@ class UnityVideoPlayerMediaKit extends UnityVideoPlayer {
         Playlist(url.map(Media.new).toList()),
         play: autoPlay,
       );
+    });
+  }
+
+  @override
+  Future<void> jumpToIndex(int index) {
+    return ensureVideoControllerInitialized((controller) async {
+      await mkPlayer.jump(index);
     });
   }
 

--- a/packages/unity_video_player/unity_video_player_platform_interface/lib/unity_video_player_platform_interface.dart
+++ b/packages/unity_video_player/unity_video_player_platform_interface/lib/unity_video_player_platform_interface.dart
@@ -453,9 +453,10 @@ abstract class UnityVideoPlayer with ChangeNotifier {
 
   Future<void> setDataSource(String url, {bool autoPlay = true});
   Future<void> setMultipleDataSource(
-    List<String> url, {
+    Iterable<String> url, {
     bool autoPlay = true,
   });
+  Future<void> jumpToIndex(int index);
 
   Future<void> setVolume(double volume);
   double get volume;


### PR DESCRIPTION
Fixes #205

To ensure a sync playback, `seekTo` was called everytime the timeline advanced in time, leading to a not smooth playback. Additionally, audio in the events was not working because of this as well.

This behavior has been removed and replaced to a similar behavior: if the player position for an event is 3 seconds late to the timeline, `seekTo` is called to ensure the correct position. If not, the event is played normally, ensuring the framerate is correctly met. Audio is synced to the current image as well.