### PR TITLE
fix: Display the correct video resolution to the user

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -264,7 +264,11 @@ class _UnityAppState extends State<UnityApp>
       await Future.microtask(() async {
         for (final player in UnityVideoPlayerInterface.players.toList()) {
           debugPrint('Disposing player ${player.hashCode}');
-          await player.dispose();
+          try {
+            await player.dispose();
+          } catch (e) {
+            debugPrint('Error disposing player: $e');
+          }
         }
       });
       windowManager.destroy();

--- a/lib/screens/layouts/video_status_label.dart
+++ b/lib/screens/layouts/video_status_label.dart
@@ -273,7 +273,9 @@ class _DeviceVideoInfo extends StatelessWidget {
         _buildTextSpan(
           context,
           title: loc.resolution,
-          data: '${device.resolutionX}x${device.resolutionY}',
+          data: '${video.player.width ?? device.resolutionX}'
+              'x'
+              '${video.player.height ?? device.resolutionY}',
         ),
         _buildTextSpan(context, title: loc.fps, data: '${video.fps}'),
         _buildTextSpan(

--- a/lib/utils/video_player.dart
+++ b/lib/utils/video_player.dart
@@ -115,8 +115,7 @@ class UnityPlayers with ChangeNotifier {
         RenderingQuality.p480 => UnityVideoQuality.p480,
         RenderingQuality.p360 => UnityVideoQuality.p360,
         RenderingQuality.p240 => UnityVideoQuality.p240,
-        RenderingQuality.automatic =>
-          UnityVideoQuality.qualityForResolutionY(device.resolutionY),
+        RenderingQuality.automatic => null,
       },
       onReload: setSource,
       title: device.fullName,

--- a/lib/utils/video_player.dart
+++ b/lib/utils/video_player.dart
@@ -138,7 +138,11 @@ class UnityPlayers with ChangeNotifier {
   static Future<void> releaseDevice(String deviceUUID) async {
     debugPrint('Releasing device $deviceUUID. ${players[deviceUUID]}');
     _reloadable.remove(deviceUUID);
-    await players[deviceUUID]?.dispose();
+    try {
+      await players[deviceUUID]?.dispose();
+    } catch (e) {
+      debugPrint('Error disposing player: $e');
+    }
     players.remove(deviceUUID);
   }
 

--- a/packages/unity_video_player/unity_video_player_main/lib/unity_video_player_main.dart
+++ b/packages/unity_video_player/unity_video_player_main/lib/unity_video_player_main.dart
@@ -177,14 +177,14 @@ class UnityVideoPlayerMediaKit extends UnityVideoPlayer {
           _fps = double.parse(fps);
           _fpsStreamController.add(_fps);
         })
-        ..observeProperty('dwidth', (width) async {
+        ..observeProperty('width', (width) async {
           debugPrint('display width: $width');
           this.width = int.tryParse(width);
           if (this.width != null && this.width! > maxSize.width) {
             maxSize = Size(this.width!.toDouble(), maxSize.height);
           }
         })
-        ..observeProperty('dheight', (height) async {
+        ..observeProperty('height', (height) async {
           debugPrint('display height: $height');
           this.height = int.tryParse(height);
           if (this.height != null && this.height! > maxSize.height) {

--- a/packages/unity_video_player/unity_video_player_platform_interface/lib/unity_video_player_platform_interface.dart
+++ b/packages/unity_video_player/unity_video_player_platform_interface/lib/unity_video_player_platform_interface.dart
@@ -270,18 +270,6 @@ enum UnityVideoQuality {
   final bool isHD;
 
   const UnityVideoQuality._({required this.resolution, this.isHD = false});
-
-  /// Returns the video quality for the video height
-  static UnityVideoQuality qualityForResolutionY(int? height) {
-    return switch (height) {
-      1080 => p1080,
-      720 => p720,
-      480 => p480,
-      360 => p360,
-      240 => p240,
-      _ => p480,
-    };
-  }
 }
 
 /// How to handle late video streams.
@@ -319,7 +307,7 @@ abstract class UnityVideoPlayer with ChangeNotifier {
   /// The [onReload] parameter is called when the video needs to be reloaded.
   /// It is usually used when the image has been old for a while.
   static UnityVideoPlayer create({
-    UnityVideoQuality quality = UnityVideoQuality.p360,
+    UnityVideoQuality? quality,
     bool enableCache = false,
     RTSPProtocol? rtspProtocol,
     Future<String>? fallbackUrl,
@@ -328,8 +316,8 @@ abstract class UnityVideoPlayer with ChangeNotifier {
     LateVideoBehavior lateVideoBehavior = LateVideoBehavior.automatic,
   }) {
     return UnityVideoPlayerInterface.instance.createPlayer(
-      width: quality.resolution.width.toInt(),
-      height: quality.resolution.height.toInt(),
+      width: quality?.resolution.width.toInt(),
+      height: quality?.resolution.height.toInt(),
       enableCache: enableCache,
       rtspProtocol: rtspProtocol,
       title: title,
@@ -362,6 +350,9 @@ abstract class UnityVideoPlayer with ChangeNotifier {
 
   int? width;
   int? height;
+  Size? get resolution => width != null && height != null
+      ? Size(width!.toDouble(), height!.toDouble())
+      : null;
   String? error;
 
   UnityVideoQuality? quality;


### PR DESCRIPTION
The video resolution is displayed to the user when the video is displayed.

It is recommended to keep the stream resolution in "Automatic" for performance reasons.