### PR TITLE
fix: macOS zoom

### DIFF
--- a/.github/workflows/flutter_analysis.yml
+++ b/.github/workflows/flutter_analysis.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2.8.0
         with:
-          channel: master
+          channel: stable
 
       - run: flutter upgrade
       - run: flutter pub get
@@ -41,7 +41,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2.8.0
         with:
-          channel: master
+          channel: stable
 
       - run: flutter upgrade
       - run: flutter pub get

--- a/README.md
+++ b/README.md
@@ -151,6 +151,16 @@ lib
 ├───firebase_options.dart                              [auto-generated firebase configuration.]
 └───main.dart                                          [entry-point of the application.]
 
+packages
+│
+├───unity_multi_window                                 [multi-window support for desktop platforms.]                  
+│
+├───unity_video_player
+│   ├───unity_video_player                             [the core video player logic.]
+│   ├───unity_video_player_flutter                     [video player used as fallback, used on embedded platforms.]
+│   ├───unity_video_player_main                        [main video player logic, used on most platforms.]
+│   ├───unity_video_player_platform_interface          [the platform interface for the video player.]
+│   └───unity_video_player_web                         [web specific video player logic, used on web.]
 ```
 
 Feel free to send any pull-requests to add any features you wish or fix any bugs you notice.

--- a/lib/models/device.dart
+++ b/lib/models/device.dart
@@ -100,8 +100,8 @@ class Device {
 
   /// The type of zoom matrix of this device.
   ///
-  /// Defaults to a 4x4 matrix.
-  final MatrixType matrixType;
+  /// If not provided, used from the settings.
+  final MatrixType? matrixType;
 
   /// A list of text overlays that will be rendered over the video.
   final List<VideoOverlay> overlays;
@@ -124,7 +124,7 @@ class Device {
     required this.server,
     this.hasPTZ = false,
     this.url,
-    this.matrixType = MatrixType.t16,
+    this.matrixType,
     this.overlays = const [],
     this.preferredStreamingType,
     this.externalData,
@@ -372,7 +372,7 @@ class Device {
       'server': server.toJson(devices: false),
       'hasPTZ': hasPTZ,
       'url': url,
-      'matrixType': matrixType.index,
+      if (matrixType != null) 'matrixType': matrixType!.index,
       'overlays': overlays.map((e) => e.toMap()).toList(),
       'preferredStreamingType': preferredStreamingType?.name,
       'externalData': externalData?.toMap(),

--- a/lib/screens/layouts/desktop/external_stream.dart
+++ b/lib/screens/layouts/desktop/external_stream.dart
@@ -28,44 +28,18 @@ import 'package:bluecherry_client/utils/extensions.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
+import 'package:unity_video_player/unity_video_player.dart';
 import 'package:uuid/uuid.dart';
 
-enum MatrixType {
-  t16(4),
-  t9(3),
-  t4(2),
-  t1(1);
+export 'package:unity_video_player/unity_video_player.dart' show MatrixType;
 
-  final int size;
-
-  const MatrixType(this.size);
-
-  @override
-  String toString() {
-    return switch (this) {
-      MatrixType.t16 => '4x4',
-      MatrixType.t9 => '3x3',
-      MatrixType.t4 => '2x2',
-      MatrixType.t1 => '1x1',
-    };
-  }
-
+extension MatrixTypeExtension on MatrixType {
   Widget get icon {
     return switch (this) {
       MatrixType.t16 => const Icon(Icons.grid_4x4),
       MatrixType.t9 => const Icon(Icons.grid_3x3),
       MatrixType.t4 => const Icon(Icons.add),
       MatrixType.t1 => const Icon(Icons.square_outlined),
-    };
-  }
-
-  MatrixType get next {
-    return switch (this) {
-      MatrixType.t16 => MatrixType.t9,
-      MatrixType.t9 => MatrixType.t4,
-      MatrixType.t4 => MatrixType.t16,
-      // ideally, t1 is never reached
-      MatrixType.t1 => MatrixType.t16,
     };
   }
 }

--- a/lib/screens/layouts/desktop/multicast_view.dart
+++ b/lib/screens/layouts/desktop/multicast_view.dart
@@ -101,7 +101,8 @@ class _MulticastViewportState extends State<MulticastViewport> {
       return const SizedBox.shrink();
     }
 
-    final size = widget.device.matrixType.size;
+    final matrixType = widget.device.matrixType ?? settings.kMatrixSize.value;
+    final size = matrixType.size;
     if (view.player.isCropped) {
       return Listener(
         onPointerSignal: (event) async {
@@ -155,9 +156,7 @@ class _MulticastViewportState extends State<MulticastViewport> {
                   onDoubleTap: () {
                     views.updateDevice(
                       widget.device,
-                      widget.device.copyWith(
-                        matrixType: widget.device.matrixType.next,
-                      ),
+                      widget.device.copyWith(matrixType: matrixType.next),
                     );
                   },
                   onPressed: () {

--- a/lib/screens/layouts/desktop/stream_data.dart
+++ b/lib/screens/layouts/desktop/stream_data.dart
@@ -250,7 +250,8 @@ class _StreamDataState extends State<StreamData> {
                   Center(
                     child: ToggleButtons(
                       isSelected: MatrixType.values.map((type) {
-                        return type.index == matrixType.index;
+                        return type.index ==
+                            (matrixType?.index ?? settings.kMatrixSize.value);
                       }).toList(),
                       onPressed: (type) => setState(() {
                         matrixType = MatrixType.values[type];

--- a/lib/screens/settings/advanced_options.dart
+++ b/lib/screens/settings/advanced_options.dart
@@ -17,6 +17,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import 'dart:io';
+
 import 'package:bluecherry_client/providers/settings_provider.dart';
 import 'package:bluecherry_client/screens/layouts/desktop/external_stream.dart';
 import 'package:bluecherry_client/screens/settings/settings_desktop.dart';
@@ -52,29 +54,47 @@ class AdvancedOptionsSettings extends StatelessWidget {
         value: settings.kDefaultBetaMatrixedZoomEnabled.value,
         onChanged: (value) {
           if (value != null) {
-            settings.updateProperty(() {
-              settings.kDefaultBetaMatrixedZoomEnabled.value = value;
-            });
+            settings.kDefaultBetaMatrixedZoomEnabled.value = value;
           }
         },
       ),
-      if (kDebugMode)
-        OptionsChooserTile<MatrixType>(
-          title: 'Default Matrix Size',
-          icon: Icons.view_quilt,
-          value: MatrixType.t4,
-          values: MatrixType.values.map((size) {
-            return Option(
-              value: size,
-              text: size.toString(),
-            );
-          }),
-          onChanged: (v) {
-            settings.updateProperty(() {
-              settings.kMatrixSize.value = v;
-            });
-          },
+      OptionsChooserTile<MatrixType>(
+        title: 'Default Matrix Size',
+        icon: Icons.view_quilt,
+        value: settings.kMatrixSize.value,
+        values: MatrixType.values.map((size) {
+          return Option(
+            value: size,
+            text: size.toString(),
+          );
+        }),
+        onChanged: (v) {
+          settings.kMatrixSize.value = v;
+        },
+      ),
+      CheckboxListTile(
+        contentPadding: DesktopSettings.horizontalPadding,
+        secondary: CircleAvatar(
+          backgroundColor: Colors.transparent,
+          foregroundColor: theme.iconTheme.color,
+          child: const Icon(Icons.center_focus_strong),
         ),
+        title: const Text('Software zoom'),
+        subtitle: Text(
+          'When enabled, the matrix zoom will not happen in the GPU. This is '
+          'useful when the hardware zoom is not working properly. '
+          '${Platform.isMacOS ? 'On macOS, this can not be disabled.' : ''}',
+        ),
+        value: Platform.isMacOS ? true : settings.kSoftwareZooming.value,
+        onChanged: Platform.isMacOS
+            ? null
+            : (v) {
+                if (v != null) {
+                  settings.kSoftwareZooming.value = v;
+                }
+              },
+        dense: false,
+      ),
       const SubHeader('Developer Options'),
       if (!kIsWeb) ...[
         FutureBuilder(
@@ -82,7 +102,11 @@ class AdvancedOptionsSettings extends StatelessWidget {
           builder: (context, snapshot) {
             return ListTile(
               contentPadding: DesktopSettings.horizontalPadding,
-              leading: const Icon(Icons.bug_report),
+              leading: CircleAvatar(
+                backgroundColor: Colors.transparent,
+                foregroundColor: theme.iconTheme.color,
+                child: const Icon(Icons.bug_report),
+              ),
               title: const Text('Open log file'),
               subtitle: Text(snapshot.data?.path ?? loc.loading),
               trailing: const Icon(Icons.navigate_next),
@@ -100,7 +124,11 @@ class AdvancedOptionsSettings extends StatelessWidget {
           builder: (context, snapshot) {
             return ListTile(
               contentPadding: DesktopSettings.horizontalPadding,
-              leading: const Icon(Icons.home),
+              leading: CircleAvatar(
+                backgroundColor: Colors.transparent,
+                foregroundColor: theme.iconTheme.color,
+                child: const Icon(Icons.home),
+              ),
               title: const Text('Open app data'),
               subtitle: Text(snapshot.data?.path ?? loc.loading),
               trailing: const Icon(Icons.navigate_next),
@@ -115,7 +143,11 @@ class AdvancedOptionsSettings extends StatelessWidget {
         ),
         CheckboxListTile(
           contentPadding: DesktopSettings.horizontalPadding,
-          secondary: const Icon(Icons.adb),
+          secondary: CircleAvatar(
+            backgroundColor: Colors.transparent,
+            foregroundColor: theme.iconTheme.color,
+            child: const Icon(Icons.adb),
+          ),
           title: const Text('Debug info'),
           subtitle: const Text(
             'Display useful information for debugging, such as video metadata '
@@ -124,9 +156,7 @@ class AdvancedOptionsSettings extends StatelessWidget {
           value: settings.kShowDebugInfo.value,
           onChanged: (v) {
             if (v != null) {
-              settings.updateProperty(() {
-                settings.kShowDebugInfo.value = v;
-              });
+              settings.kShowDebugInfo.value = v;
             }
           },
           dense: false,
@@ -134,7 +164,11 @@ class AdvancedOptionsSettings extends StatelessWidget {
         if (kDebugMode)
           CheckboxListTile(
             contentPadding: DesktopSettings.horizontalPadding,
-            secondary: const Icon(Icons.network_check),
+            secondary: CircleAvatar(
+              backgroundColor: Colors.transparent,
+              foregroundColor: theme.iconTheme.color,
+              child: const Icon(Icons.network_check),
+            ),
             title: const Text('Network Usage'),
             subtitle: const Text(
               'Display network usage information over playing videos.',
@@ -151,7 +185,11 @@ class AdvancedOptionsSettings extends StatelessWidget {
           ),
         ListTile(
           contentPadding: DesktopSettings.horizontalPadding,
-          leading: const Icon(Icons.restore),
+          leading: CircleAvatar(
+            backgroundColor: Colors.transparent,
+            foregroundColor: theme.iconTheme.color,
+            child: const Icon(Icons.restore),
+          ),
           title: const Text('Restore Defaults'),
           subtitle: const Text(
             'Restore all settings to their default values. This will not '

--- a/lib/screens/settings/advanced_options.dart
+++ b/lib/screens/settings/advanced_options.dart
@@ -72,7 +72,7 @@ class AdvancedOptionsSettings extends StatelessWidget {
           settings.kMatrixSize.value = v;
         },
       ),
-      CheckboxListTile(
+      CheckboxListTile.adaptive(
         contentPadding: DesktopSettings.horizontalPadding,
         secondary: CircleAvatar(
           backgroundColor: Colors.transparent,
@@ -141,7 +141,7 @@ class AdvancedOptionsSettings extends StatelessWidget {
             );
           },
         ),
-        CheckboxListTile(
+        CheckboxListTile.adaptive(
           contentPadding: DesktopSettings.horizontalPadding,
           secondary: CircleAvatar(
             backgroundColor: Colors.transparent,
@@ -162,7 +162,7 @@ class AdvancedOptionsSettings extends StatelessWidget {
           dense: false,
         ),
         if (kDebugMode)
-          CheckboxListTile(
+          CheckboxListTile.adaptive(
             contentPadding: DesktopSettings.horizontalPadding,
             secondary: CircleAvatar(
               backgroundColor: Colors.transparent,

--- a/lib/utils/video_player.dart
+++ b/lib/utils/video_player.dart
@@ -119,6 +119,8 @@ class UnityPlayers with ChangeNotifier {
       },
       onReload: setSource,
       title: device.fullName,
+      matrixType: device.matrixType,
+      softwareZoom: settings.kSoftwareZooming.value,
     )
       ..setVolume(0.0)
       ..setSpeed(1.0);

--- a/lib/utils/video_player.dart
+++ b/lib/utils/video_player.dart
@@ -119,7 +119,7 @@ class UnityPlayers with ChangeNotifier {
       },
       onReload: setSource,
       title: device.fullName,
-      matrixType: device.matrixType,
+      matrixType: device.matrixType ?? settings.kMatrixSize.value,
       softwareZoom: settings.kSoftwareZooming.value,
     )
       ..setVolume(0.0)

--- a/packages/unity_video_player/unity_video_player_flutter/lib/unity_video_player_flutter.dart
+++ b/packages/unity_video_player/unity_video_player_flutter/lib/unity_video_player_flutter.dart
@@ -32,6 +32,8 @@ class UnityVideoPlayerFlutterInterface extends UnityVideoPlayerInterface {
     RTSPProtocol? rtspProtocol,
     VoidCallback? onReload,
     String? title,
+    MatrixType matrixType = MatrixType.t16,
+    bool softwareZoom = false,
   }) {
     final player = UnityVideoPlayerFlutter(
       width: width,

--- a/packages/unity_video_player/unity_video_player_main/lib/unity_video_player_main.dart
+++ b/packages/unity_video_player/unity_video_player_main/lib/unity_video_player_main.dart
@@ -474,7 +474,7 @@ class UnityVideoPlayerMediaKit extends UnityVideoPlayer {
       );
 
       debugPrint(
-        'Cropping | row=$row | col=$col | size=$maxSize | viewport=$viewportRect',
+        'Cropping $softwareZoom | row=$row | col=$col | size=$maxSize | viewport=$viewportRect',
       );
 
       await crop(viewportRect);

--- a/packages/unity_video_player/unity_video_player_main/lib/unity_video_player_main.dart
+++ b/packages/unity_video_player/unity_video_player_main/lib/unity_video_player_main.dart
@@ -107,10 +107,9 @@ class _MKVideoState extends State<_MKVideo> {
   @override
   void didUpdateWidget(covariant _MKVideo oldWidget) {
     super.didUpdateWidget(oldWidget);
-    videoKey.currentState?.update(
-      fit: widget.fit,
-      fill: widget.color,
-    );
+    if (oldWidget.fit != widget.fit || oldWidget.color != widget.color) {
+      videoKey.currentState?.update(fit: widget.fit, fill: widget.color);
+    }
   }
 
   @override

--- a/packages/unity_video_player/unity_video_player_main/lib/unity_video_player_main.dart
+++ b/packages/unity_video_player/unity_video_player_main/lib/unity_video_player_main.dart
@@ -394,6 +394,8 @@ class UnityVideoPlayerMediaKit extends UnityVideoPlayer {
   @override
   Future<void> crop(int row, int col, int size) async {
     if (kIsWeb) return;
+    // Usage as dynamic is necessary because the property is not available on the
+    // web platform, and the compiler will complain about it.
     final player = mkPlayer.platform as dynamic;
     // On linux, the mpv binaries used come from the distros (sudo apt install mpv ...)
     // As of now (18 nov 2023), the "video-crop" parameter is not supported on
@@ -401,8 +403,10 @@ class UnityVideoPlayerMediaKit extends UnityVideoPlayer {
     // the same thing. "video-crop" is preferred on the other platforms because
     // of its performance.
 
+    final useVideoFilter = Platform.isLinux || Platform.isMacOS;
+
     if (row == -1 || col == -1 || size == -1) {
-      if (Platform.isLinux) {
+      if (useVideoFilter) {
         await player.setProperty('vf', 'crop=');
       } else {
         await player.setProperty('video-crop', '0x0+0+0');
@@ -423,7 +427,7 @@ class UnityVideoPlayerMediaKit extends UnityVideoPlayer {
         'Cropping | row=$row | col=$col | size=$maxSize | viewport=$viewportRect',
       );
 
-      if (Platform.isLinux) {
+      if (useVideoFilter) {
         await player.setProperty(
           'vf',
           'crop='

--- a/packages/unity_video_player/unity_video_player_main/lib/unity_video_player_main.dart
+++ b/packages/unity_video_player/unity_video_player_main/lib/unity_video_player_main.dart
@@ -460,8 +460,8 @@ class UnityVideoPlayerMediaKit extends UnityVideoPlayer {
       final platform = mkPlayer.platform as dynamic;
 
       await platform.unobserveProperty('estimated-vf-fps');
-      await platform.unobserveProperty('dwidth');
-      await platform.unobserveProperty('dheight');
+      await platform.unobserveProperty('width');
+      await platform.unobserveProperty('height');
     }
     await _fpsStreamController.close();
     await mkPlayer.dispose();

--- a/packages/unity_video_player/unity_video_player_platform_interface/lib/unity_video_player_platform_interface.dart
+++ b/packages/unity_video_player/unity_video_player_platform_interface/lib/unity_video_player_platform_interface.dart
@@ -165,6 +165,16 @@ class UnityVideoView extends StatefulWidget {
   ///   * [Hero.tag], the identifier for this particular hero.
   final dynamic heroTag;
 
+  /// The matrix type to use for the video view.
+  ///
+  /// Defaults to [MatrixType.t16].
+  final MatrixType matrixType;
+
+  /// Whether to use software zoom.
+  ///
+  /// Defaults to `false`.
+  final bool softwareZoom;
+
   /// Creates a new video view.
   const UnityVideoView({
     super.key,
@@ -174,6 +184,8 @@ class UnityVideoView extends StatefulWidget {
     this.videoBuilder,
     this.color = const Color(0xFF000000),
     this.heroTag,
+    this.matrixType = MatrixType.t16,
+    this.softwareZoom = false,
   });
 
   static VideoViewInheritance of(BuildContext context) {
@@ -289,6 +301,9 @@ abstract class UnityVideoPlayer with ChangeNotifier {
   VoidCallback? onReload;
   late LateVideoBehavior lateVideoBehavior;
 
+  MatrixType matrixType = MatrixType.t1;
+  bool softwareZoom = false;
+
   /// Creates a new [UnityVideoPlayer] instance.
   ///
   /// The [quality] parameter is used to set the rendering resolution of the
@@ -314,6 +329,8 @@ abstract class UnityVideoPlayer with ChangeNotifier {
     VoidCallback? onReload,
     String? title,
     LateVideoBehavior lateVideoBehavior = LateVideoBehavior.automatic,
+    MatrixType matrixType = MatrixType.t1,
+    bool softwareZoom = false,
   }) {
     return UnityVideoPlayerInterface.instance.createPlayer(
       width: quality?.resolution.width.toInt(),
@@ -325,7 +342,9 @@ abstract class UnityVideoPlayer with ChangeNotifier {
       ..quality = quality
       ..fallbackUrl = fallbackUrl
       ..onReload = onReload
-      ..lateVideoBehavior = lateVideoBehavior;
+      ..lateVideoBehavior = lateVideoBehavior
+      ..matrixType = matrixType
+      ..softwareZoom = softwareZoom;
   }
 
   static const timerInterval = Duration(seconds: 6);
@@ -538,5 +557,36 @@ abstract class UnityVideoPlayer with ChangeNotifier {
     _isImageOld = false;
 
     super.dispose();
+  }
+}
+
+enum MatrixType {
+  t16(4),
+  t9(3),
+  t4(2),
+  t1(1);
+
+  final int size;
+
+  const MatrixType(this.size);
+
+  @override
+  String toString() {
+    return switch (this) {
+      MatrixType.t16 => '4x4',
+      MatrixType.t9 => '3x3',
+      MatrixType.t4 => '2x2',
+      MatrixType.t1 => '1x1',
+    };
+  }
+
+  MatrixType get next {
+    return switch (this) {
+      MatrixType.t16 => MatrixType.t9,
+      MatrixType.t9 => MatrixType.t4,
+      MatrixType.t4 => MatrixType.t16,
+      // ideally, t1 is never reached
+      MatrixType.t1 => MatrixType.t16,
+    };
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   flutter_simple_treeview: ^3.0.2
   sliver_tools: ^0.2.12
 
-  intl: ^0.19.0
+  intl: ^0.18.1
   flutter_localized_locales: ^2.0.5
   duration: ^3.0.13
   firebase_core: 2.10.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   flutter_simple_treeview: ^3.0.2
   sliver_tools: ^0.2.12
 
-  intl: ^0.18.1
+  intl: ^0.19.0
   flutter_localized_locales: ^2.0.5
   duration: ^3.0.13
   firebase_core: 2.10.0


### PR DESCRIPTION
Implements software zooming.

On Windows, the "video-crop" option from mpv is used to crop the video. On Linux, "vf=crop" is used. None of these options are available for us when running on the macOS. The solution, then, is to manually zoom into the desired area (thus the name software zooming).

Both software zooming and hardware zooming are digital zooms, and both should have similar performance. Software zoom is forced on macOS, but is available on all platforms as an option in the `Settings -> Additional Settings`. 

Additionally,

* fix(leak): Correctly unobserve the width and height properties;
* fix(performance): Do not update the video properties if it has not changed;
* fix(ux): Correctly persist all settings options;
* new: Added default matrix size.

note: 3x3 and 2x2 doesn't behave correctly when using the new zooming implementation.
