### PR TITLE
bug fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,7 +245,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev mpv libmpv-dev dpkg-dev p7zip-full p7zip-rar
+          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev mpv libmpv-dev dpkg-dev p7zip-full p7zip-rar libsecret-1-0 libjsoncpp-dev
 
       - name: Install Flutter
         uses: subosito/flutter-action@v2.8.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -243,9 +243,11 @@ jobs:
           submodules: recursive
 
       - name: Install dependencies
+        # https://docs.flutter.dev/platform-integration/linux/building#prepare-linux-apps-for-distribution
+        # https://pub.dev/packages/flutter_secure_storage#configure-linux-version
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev mpv libmpv-dev dpkg-dev p7zip-full p7zip-rar libsecret-1-0 libjsoncpp-dev
+          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev mpv libmpv-dev dpkg-dev p7zip-full p7zip-rar libsecret-1-dev libjsoncpp-dev
 
       - name: Install Flutter
         uses: subosito/flutter-action@v2.8.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -381,7 +381,7 @@ jobs:
         uses: subosito/flutter-action@v2.8.0
         with:
           channel: "stable"
-          flutter-version: 3.24.0
+          flutter-version: 3.27.0
           cache: false
 
       - name: Initiate Flutter

--- a/lib/screens/events_timeline/desktop/timeline.dart
+++ b/lib/screens/events_timeline/desktop/timeline.dart
@@ -359,7 +359,13 @@ class Timeline extends ChangeNotifier {
   DateTime get currentDate => date.add(currentPosition);
 
   void seekTo(Duration position) {
-    currentPosition = position;
+    if (position < Duration.zero) {
+      currentPosition = Duration.zero;
+    } else if (position > endPosition) {
+      currentPosition = endPosition;
+    } else {
+      currentPosition = position;
+    }
     notifyListeners();
 
     forEachEvent((tile, event) async {
@@ -375,8 +381,6 @@ class Timeline extends ChangeNotifier {
     });
   }
 
-  // TODO(bdlukaa): Only make it possible to seek between bounds.
-  //                Currently, is is possible to seek before and after the day.
   /// Seeks forward by [duration]
   void seekForward([Duration duration = const Duration(seconds: 15)]) =>
       seekTo(currentPosition + duration);

--- a/lib/screens/events_timeline/desktop/timeline_card.dart
+++ b/lib/screens/events_timeline/desktop/timeline_card.dart
@@ -251,7 +251,10 @@ class _TimelineCardState extends State<TimelineCard> {
                             '/events',
                             arguments: {
                               'event': currentEvent.event,
-                              'videoPlayer': widget.tile.videoController,
+                              // Do not pass the video controller to the fullscreen
+                              // view because we don't want to desync the video
+                              // from the Timeline. https://github.com/bluecherrydvr/unity/issues/306
+                              // 'videoPlayer': widget.tile.videoController,
                             },
                           );
 

--- a/lib/screens/layouts/desktop/layout_view.dart
+++ b/lib/screens/layouts/desktop/layout_view.dart
@@ -417,6 +417,10 @@ class _LayoutViewState extends State<LayoutView> {
                                     await widget.layout.setVolume(value);
                                     if (mounted) setState(() {});
                                   },
+                                  onChangeEnd: (value) async {
+                                    await widget.layout.setVolume(value);
+                                    view.save();
+                                  },
                                 ),
                               ),
                             SquaredIconButton(

--- a/lib/screens/layouts/desktop/layout_view.dart
+++ b/lib/screens/layouts/desktop/layout_view.dart
@@ -410,14 +410,11 @@ class _LayoutViewState extends State<LayoutView> {
                               SizedBox(
                                 height: 24.0,
                                 child: Slider(
-                                  value: widget.layout.devices
-                                      .map((device) => device.volume)
-                                      .findMaxDuplicatedElementInList()
-                                      .toDouble(),
+                                  value: volume,
                                   divisions: 100,
                                   label: '${(volume * 100).round()}%',
                                   onChanged: (value) async {
-                                    widget.layout.setVolume(volume);
+                                    await widget.layout.setVolume(value);
                                     if (mounted) setState(() {});
                                   },
                                 ),

--- a/lib/screens/layouts/desktop/layout_view.dart
+++ b/lib/screens/layouts/desktop/layout_view.dart
@@ -357,8 +357,7 @@ class _LayoutViewState extends State<LayoutView> {
                 childAspectRatio: kHorizontalAspectRatio,
                 reorderable: widget.onReorder != null,
                 onReorder: widget.onReorder ?? (a, b) {},
-                padding:
-                    settings.isImmersiveMode ? EdgeInsets.zero : kGridPadding,
+                padding: EdgeInsets.zero,
                 children: devices.map((device) {
                   return DesktopDeviceTile(device: device);
                 }).toList(),
@@ -508,7 +507,9 @@ class _LayoutViewState extends State<LayoutView> {
                   ),
                 ),
               if (devices.isNotEmpty)
-                Expanded(child: Center(child: child))
+                Expanded(
+                  child: SizedBox.fromSize(size: Size.infinite, child: child),
+                )
               else
                 Expanded(
                   child: Center(child: Text('Add a camera')),

--- a/lib/screens/layouts/desktop/sidebar.dart
+++ b/lib/screens/layouts/desktop/sidebar.dart
@@ -248,23 +248,29 @@ class ServerEntry extends StatelessWidget {
             } else if (isSidebarHovering && devices.isNotEmpty) {
               return SquaredIconButton(
                 icon: Icon(
-                  isAllInView ? Icons.playlist_remove : Icons.playlist_add,
+                  view.isLayoutLocked(view.currentLayout)
+                      ? Icons.lock
+                      : isAllInView
+                          ? Icons.playlist_remove
+                          : Icons.playlist_add,
                 ),
                 tooltip: isAllInView ? loc.removeAllFromView : loc.addAllToView,
-                onPressed: () {
-                  if (isAllInView) {
-                    view.removeDevicesFromCurrentLayout(
-                      devices,
-                    );
-                  } else {
-                    for (final device in devices) {
-                      if (device.status &&
-                          !view.currentLayout.devices.contains(device)) {
-                        view.add(device);
-                      }
-                    }
-                  }
-                },
+                onPressed: view.isLayoutLocked(view.currentLayout)
+                    ? null
+                    : () {
+                        if (isAllInView) {
+                          view.removeDevicesFromCurrentLayout(
+                            devices,
+                          );
+                        } else {
+                          for (final device in devices) {
+                            if (device.status &&
+                                !view.currentLayout.devices.contains(device)) {
+                              view.add(device);
+                            }
+                          }
+                        }
+                      },
               );
             } else {
               return const SizedBox.shrink();

--- a/lib/screens/layouts/desktop/sidebar.dart
+++ b/lib/screens/layouts/desktop/sidebar.dart
@@ -36,6 +36,7 @@ class _DesktopSidebarState extends State<DesktopSidebar> {
   var isSidebarHovering = false;
   var searchQuery = '';
   final Map<Server, List<Device>> _servers = <Server, List<Device>>{};
+  final _serversEntries = <MapEntry<Server, List<Device>>>[];
 
   @override
   void didChangeDependencies() {
@@ -51,6 +52,8 @@ class _DesktopSidebarState extends State<DesktopSidebar> {
       final devices = server.devices.sorted(searchQuery: searchQuery);
       _servers[server] = devices;
     }
+    _serversEntries.clear();
+    _serversEntries.addAll(_servers.entries.toList(growable: false));
   }
 
   @override
@@ -81,26 +84,27 @@ class _DesktopSidebarState extends State<DesktopSidebar> {
               child: MouseRegion(
                 onEnter: (e) => setState(() => isSidebarHovering = true),
                 onExit: (e) => setState(() => isSidebarHovering = false),
-                // Add another material here because its descendants must be clipped.
+                // Add another [Material] here because its descendants must be clipped.
                 child: Material(
                   type: MaterialType.transparency,
                   child: CustomScrollView(slivers: [
-                    ..._servers.entries.toList(growable: false).map((entry) {
-                      final server = entry.key;
-                      final devices = entry.value.where((device) {
-                        if (!device.status &&
-                            !settings.kListOfflineDevices.value) {
-                          return false;
-                        }
-                        return true;
-                      }).toList();
-                      return ServerEntry(
-                        server: server,
-                        devices: devices,
-                        searchQuery: searchQuery,
-                        isSidebarHovering: isSidebarHovering,
-                      );
-                    }),
+                    for (var MapEntry(key: server, value: devices)
+                        in _serversEntries)
+                      () {
+                        devices = devices.where((device) {
+                          if (!device.status &&
+                              !settings.kListOfflineDevices.value) {
+                            return false;
+                          }
+                          return true;
+                        }).toList();
+                        return ServerEntry(
+                          server: server,
+                          devices: devices,
+                          searchQuery: searchQuery,
+                          isSidebarHovering: isSidebarHovering,
+                        );
+                      }(),
                   ]),
                 ),
               ),

--- a/lib/screens/servers/configure_dvr_server.dart
+++ b/lib/screens/servers/configure_dvr_server.dart
@@ -426,13 +426,10 @@ class _ConfigureDVRServerScreenState extends State<ConfigureDVRServerScreen> {
 
       final name = nameController.text.trim();
       final hostname = getServerHostname(hostnameController.text.trim());
+      final port = int.parse(portController.text.trim());
 
       if (ServersProvider.instance.servers.any((s) {
-        final serverHost = Uri.parse(s.login).host;
-        final newServerHost = Uri.parse(hostname).host;
-        return serverHost.isNotEmpty &&
-            newServerHost.isNotEmpty &&
-            serverHost == newServerHost;
+        return s.ip == hostname && s.port == port;
       })) {
         showDialog(
           context: context,
@@ -454,7 +451,6 @@ class _ConfigureDVRServerScreenState extends State<ConfigureDVRServerScreen> {
           state = _ServerAddState.checkingServerCredentials;
         });
       }
-      final port = int.parse(portController.text.trim());
       final (code, server) = await API.instance.checkServerCredentials(
         Server(
           name: name,

--- a/lib/utils/app_links/app_links.dart
+++ b/lib/utils/app_links/app_links.dart
@@ -220,6 +220,7 @@ Future<void> handleArgs(
     if (serverResult == null) {
       throw ArgumentError('Server $server not found');
     } else {
+      await ServersProvider.instance.refreshDevices();
       final deviceResult = serverResult.devices.firstWhereOrNull((d) {
         return d.id.toString() == camera;
       });

--- a/lib/utils/extensions.dart
+++ b/lib/utils/extensions.dart
@@ -173,11 +173,14 @@ extension IterableTExtension<T> on Iterable<T> {
   ///
   /// This is useful when you have a list of elements and you want to know which
   /// element appears the most.
-  T findMaxDuplicatedElementInList() => fold<Map<T, int>>(
-          {},
-          (map, element) =>
-              map..update(element, (value) => value + 1, ifAbsent: () => 1))
-      .entries
-      .reduce((e1, e2) => e1.value > e2.value ? e1 : e2)
-      .key;
+  T findMaxDuplicatedElementInList() {
+    if (length == 1) return first;
+    return fold<Map<T, int>>(
+            {},
+            (map, element) =>
+                map..update(element, (value) => value + 1, ifAbsent: () => 1))
+        .entries
+        .reduce((e1, e2) => e1.value > e2.value ? e1 : e2)
+        .key;
+  }
 }

--- a/lib/utils/window.dart
+++ b/lib/utils/window.dart
@@ -33,6 +33,11 @@ import 'package:provider/provider.dart';
 import 'package:unity_multi_window/unity_multi_window.dart';
 import 'package:window_manager/window_manager.dart';
 
+/// The small window size.
+///
+/// This is used in debug mode and when the window is a sub window.
+const kSmallWindowSize = Size(300, 200);
+
 /// The initial size of the window
 const kInitialWindowSize = Size(1066, 645);
 
@@ -56,7 +61,11 @@ Future<void> configureWindow({bool? fullscreen}) async {
     await WindowManager.instance.ensureInitialized();
     await windowManager.waitUntilReadyToShow(
       WindowOptions(
-        minimumSize: kDebugMode ? Size(100, 100) : kInitialWindowSize,
+        minimumSize: () {
+          if (kDebugMode) return kSmallWindowSize;
+          if (isSubWindow) return kSmallWindowSize;
+          return kInitialWindowSize;
+        }(),
         skipTaskbar: false,
         titleBarStyle: TitleBarStyle.hidden,
         windowButtonVisibility: true,

--- a/lib/utils/window.dart
+++ b/lib/utils/window.dart
@@ -134,7 +134,7 @@ extension DeviceWindowExtension on Device {
 
     assert(!isEmbedded, 'Can not open a new window in an embedded environment');
 
-    debugPrint('Opening a new window');
+    debugPrint('Opening a new window for device $name (${server.name}#$id)');
     final window = await MultiWindow.run([
       '--theme',
       SettingsProvider.instance.kThemeMode.value.name,

--- a/packages/unity_video_player/unity_video_player_platform_interface/lib/unity_video_player_platform_interface.dart
+++ b/packages/unity_video_player/unity_video_player_platform_interface/lib/unity_video_player_platform_interface.dart
@@ -239,9 +239,11 @@ abstract class UnityVideoPlayer with ChangeNotifier {
   /// Implementations must call this when the video source is ready to be
   /// listened to.
   late final VoidCallback onReady;
+  bool _isReady = false;
 
   UnityVideoPlayer({this.width, this.height}) {
     onReady = () {
+      _isReady = true;
       _onErrorSubscription = onError.listen(_onError);
       _onDurationUpdateSubscription =
           onDurationUpdate.listen(_onDurationUpdate);
@@ -446,14 +448,16 @@ abstract class UnityVideoPlayer with ChangeNotifier {
   @mustCallSuper
   @override
   Future<void> dispose() async {
-    try {
-      _onDurationUpdateSubscription.cancel();
-      _onErrorSubscription.cancel();
-      _onPositionUpdateSubscription.cancel();
-      _fpsSubscription.cancel();
-      _oldImageTimer?.cancel();
-    } catch (error, stack) {
-      debugPrint('Tried to cancel subscriptions but failed: $error, $stack');
+    if (_isReady) {
+      try {
+        _onDurationUpdateSubscription.cancel();
+        _onErrorSubscription.cancel();
+        _onPositionUpdateSubscription.cancel();
+        _fpsSubscription.cancel();
+        _oldImageTimer?.cancel();
+      } catch (error, stack) {
+        debugPrint('Tried to cancel subscriptions but failed: $error, $stack');
+      }
     }
     _lastImageTime = null;
     _isImageOld = false;


### PR DESCRIPTION
- [x] Fixes #291
- [x] Fixes #302
- [x] Fixes #306
- [x] Only allow to seek between bounds in the Timeline of Events
- [x] Secondary Windows are allowed to be smaller: 300x200 pixels
- [x] Ensure devices are fetched from remote before using them when opening from command line using `--server` and `--camera` options
- [x] Correctly calculate the size of the reorderable grid children
       The entire reorderable grid was being calculated incorrectly, leading to clipping and extra space that just didn't fell right. The logic was adjusted to fit all the items inside the grid. Now, both the Layouts View and Timeline of Events view feel natural.
- [x] Do not allow to add the a server if it is already added